### PR TITLE
Goblint's stdout/stderr redirected into output #8 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,23 @@
 			<artifactId>gson</artifactId>
 			<version>2.8.6</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.zeroturnaround</groupId>
+			<artifactId>zt-exec</artifactId>
+			<version>1.12</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.14.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.14.1</version>
+		</dependency>
  </dependencies>
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/GoblintAnalysis.java
+++ b/src/main/java/GoblintAnalysis.java
@@ -167,12 +167,13 @@ public class GoblintAnalysis implements ServerAnalysis {
             log.debug("Reading analysis results from json");
             // Read json objects as an array
             JsonArray resultArray = JsonParser.parseReader(new FileReader(new File(pathToJsonResult))).getAsJsonArray();
+            GsonBuilder builder = new GsonBuilder();
+            // Add deserializer for tags
+            builder.registerTypeAdapter(GoblintResult.tag.class, new TagInterfaceAdapter());
+            Gson gson = builder.create();
             // For each JsonObject
             for (int i = 0; i < resultArray.size(); i++) {
                 // Deserailize them into GoblintResult objects
-                GsonBuilder builder = new GsonBuilder();
-                builder.registerTypeAdapter(GoblintResult.tag.class, new TagInterfaceAdapter());
-                Gson gson = builder.create();
                 GoblintResult goblintResult = gson.fromJson(resultArray.get(i), GoblintResult.class);
                 // Add sourcefileURL to object for generationg the position
                 goblintResult.sourcefileURL = this.sourcefileURL;

--- a/src/main/java/GoblintAnalysis.java
+++ b/src/main/java/GoblintAnalysis.java
@@ -130,8 +130,8 @@ public class GoblintAnalysis implements ServerAnalysis {
             // construct command to run
             this.commands = new String[]{"goblint", "--conf", "goblint.json", "--set", "result", "json-messages", "-o", pathToJsonResult, fileToAnalyze};
         } catch (MalformedURLException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            log.error("An error occured while trying parse the url of the file to be analyzed. " + e.getMessage());
+            return false;
         }
         try {
             // run command

--- a/src/main/java/GoblintAnalysis.java
+++ b/src/main/java/GoblintAnalysis.java
@@ -104,21 +104,21 @@ public class GoblintAnalysis implements ServerAnalysis {
         log.debug("Waiting for Goblint to run...");
         System.err.println("---------------------- Goblint's dump start ----------------------");
         ProcessResult process = new ProcessExecutor()
-                            .directory(dirPath)
-                            .command(command)
-                            .redirectOutput(System.err)
-                            .redirectError(System.err)
-                            .execute();
+                .directory(dirPath)
+                .command(command)
+                .redirectOutput(System.err)
+                .redirectError(System.err)
+                .execute();
         System.err.println("----------------------- Goblint's dump end -----------------------");
         return process;
-      }
+    }
 
     /**
      * Runs the command in the project root directory
      * to let goblint generate the json file with analysis results.
      *
-     * @param file    the file on which to run the analysis.
-     * @return        returns true if goblint finished the analyse and json was generated sucessfully, false otherwise
+     * @param file the file on which to run the analysis.
+     * @return returns true if goblint finished the analyse and json was generated sucessfully, false otherwise
      */
     private boolean generateJson(Module file) {
         SourceFileModule sourcefile = (SourceFileModule) file;
@@ -128,19 +128,19 @@ public class GoblintAnalysis implements ServerAnalysis {
             // file to be analyzed
             String fileToAnalyze = sourcefileURL.getFile();
             // construct command to run
-            this.commands = new String[] { "goblint", "--conf", "goblint.json", "--set", "result", "json-messages", "-o", pathToJsonResult, fileToAnalyze };
-            } catch (MalformedURLException e) {
-                // TODO Auto-generated catch block
-                e.printStackTrace();
-            }
+            this.commands = new String[]{"goblint", "--conf", "goblint.json", "--set", "result", "json-messages", "-o", pathToJsonResult, fileToAnalyze};
+        } catch (MalformedURLException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
         try {
             // run command
             log.info("Goblint run with command: " + String.join(" ", this.getCommand()));
             ProcessResult commandRunProcess = this.runCommand(new File(System.getProperty("user.dir")));
             if (commandRunProcess.getExitValue() != 0) {
                 magpieServer.forwardMessageToClient(
-                    new MessageParams(MessageType.Error, 
-                        "Goblint exited with an error."));
+                        new MessageParams(MessageType.Error,
+                                "Goblint exited with an error."));
                 log.error("Goblint exited with an error.");
                 return false;
             }

--- a/src/main/java/GoblintAnalysisResult.java
+++ b/src/main/java/GoblintAnalysisResult.java
@@ -97,5 +97,5 @@ public class GoblintAnalysisResult implements AnalysisResult {
         }
         return code;
     }
-    
+
 }

--- a/src/main/java/GoblintPosition.java
+++ b/src/main/java/GoblintPosition.java
@@ -1,5 +1,6 @@
 import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
 import com.ibm.wala.classLoader.IMethod;
+
 import java.io.Reader;
 import java.net.URL;
 
@@ -26,7 +27,7 @@ public class GoblintPosition implements Position {
         this.columnEnd = columnEnd;
         this.sourcefileURL = sourcefileURL;
     }
-    
+
     @Override
     public int getFirstCol() {
         return columnStart;

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -8,14 +8,21 @@ import magpiebridge.core.ServerAnalysis;
 import magpiebridge.core.ServerConfiguration;
 import magpiebridge.core.ToolAnalysis;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 public class Main {
+
+    private static final Logger log = LogManager.getLogger(Main.class);
 
     public static void main(String... args) {
         // create server
         MagpieServer server = createServer();
+        log.info("Server created");
         // launch the server only if there is a goblint conf file present
         if (new File(System.getProperty("user.dir") + "/" + "goblint.json").exists()) {
             server.launchOnStdio();
+            log.info("Server launched");
         }
     }
 
@@ -28,8 +35,8 @@ public class Main {
         // define language
         String language = "c";
         // add analysis to the MagpieServer
-        ToolAnalysis toolAnalysis = new GoblintAnalysis(server);
-        Either<ServerAnalysis, ToolAnalysis> analysis = Either.forRight(toolAnalysis);
+        ServerAnalysis serverAnalysis = new GoblintAnalysis(server);
+        Either<ServerAnalysis, ToolAnalysis> analysis = Either.forLeft(serverAnalysis);
         server.addAnalysis(analysis, language);
 
         return server;

--- a/src/main/java/TagInterfaceAdapter.java
+++ b/src/main/java/TagInterfaceAdapter.java
@@ -1,4 +1,5 @@
 import java.lang.reflect.Type;
+
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
@@ -10,8 +11,10 @@ public class TagInterfaceAdapter implements JsonDeserializer<Object> {
     @Override
     public Object deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
         JsonObject jsonObject = jsonElement.getAsJsonObject();
-        if (jsonObject.has("Category")) return jsonDeserializationContext.deserialize(jsonObject, GoblintResult.tag.Category.class);
-        if (jsonObject.has("CWE")) return jsonDeserializationContext.deserialize(jsonObject, GoblintResult.tag.CWE.class);
+        if (jsonObject.has("Category"))
+            return jsonDeserializationContext.deserialize(jsonObject, GoblintResult.tag.Category.class);
+        if (jsonObject.has("CWE"))
+            return jsonDeserializationContext.deserialize(jsonObject, GoblintResult.tag.CWE.class);
         return null;
     }
 

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="WARN">
-  <Properties>
-    <!-- <Property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} [%t][%logger] %-5level - %msg%n</Property> --> <!--  change pattern to this to see date, threads and loggers (classes) for logs  -->
-    <Property name="pattern">%d{HH:mm:ss.SSS} %-5level - %msg%n</Property>
-  </Properties>
-  <Appenders>
-    <Console name="stderr" target="SYSTEM_ERR">
-      <PatternLayout pattern="${pattern}"/>
-    </Console>
-  </Appenders>
-  <Loggers>
-    <Root level="INFO"> <!--  change info to debug here to see the debug logs while developing  -->
-      <AppenderRef ref="stderr"/>
-    </Root>
-  </Loggers>
-  
+    <Properties>
+        <!-- <Property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} [%t][%logger] %-5level - %msg%n</Property> --> <!--  change pattern to this to see date, threads and loggers (classes) for logs  -->
+        <Property name="pattern">%d{HH:mm:ss.SSS} %-5level - %msg%n</Property>
+    </Properties>
+    <Appenders>
+        <Console name="stderr" target="SYSTEM_ERR">
+            <PatternLayout pattern="${pattern}"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO"> <!--  change info to debug here to see the debug logs while developing  -->
+            <AppenderRef ref="stderr"/>
+        </Root>
+    </Loggers>
 </Configuration>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Properties>
+    <!-- <Property name="pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} [%t][%logger] %-5level - %msg%n</Property> --> <!--  change pattern to this to see date, threads and loggers (classes) for logs  -->
+    <Property name="pattern">%d{HH:mm:ss.SSS} %-5level - %msg%n</Property>
+  </Properties>
+  <Appenders>
+    <Console name="stderr" target="SYSTEM_ERR">
+      <PatternLayout pattern="${pattern}"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="INFO"> <!--  change info to debug here to see the debug logs while developing  -->
+      <AppenderRef ref="stderr"/>
+    </Root>
+  </Loggers>
+  
+</Configuration>


### PR DESCRIPTION
### Goblint's stdout/stderr redirected into output #8 and logging support added

* All debug info that Goblint dumps is now redirected so that it is shown in the Output console in vscode. This is done with **zt-exec**, which has a method to redirect `stdout` and `stderr` to `System.err`.
* As the default runCommand method from` MagpieBridge`'s `ToolAnalysis` class is no longer used due to the need to use `zt-exec`'s `ProcessExecutor` instead of `ProcessBuilder`, GoblintAnalysis now implements `ServerAnalysis` interface instead of `ToolAnalysis`.
* Logging support was added with **Log4j.** Logs are shown in the Output console as well. The default level is info, but debug level can be used for development. For using debug level, `log4j2.xml` file must be edited.
* On the info level, the command Goblint was executed with is logged as well as some additional info (e.g. magpie server started).
* Some additional exception handling was added to prevent reading from a JSON file after the Goblint run fails, as there were exceptions when another file's analysis result was tried to be shown in a different file.