### PR TITLE
Gobpie uses location ranges provided by Goblint #12

### DIFF
--- a/src/main/java/GoblintAnalysis.java
+++ b/src/main/java/GoblintAnalysis.java
@@ -118,7 +118,7 @@ public class GoblintAnalysis implements ServerAnalysis {
      * to let goblint generate the json file with analysis results.
      *
      * @param file the file on which to run the analysis.
-     * @return returns true if goblint finished the analyse and json was generated sucessfully, false otherwise
+     * @return returns true if goblint finished the analysis and json was generated sucessfully, false otherwise
      */
     private boolean generateJson(Module file) {
         SourceFileModule sourcefile = (SourceFileModule) file;
@@ -175,14 +175,12 @@ public class GoblintAnalysis implements ServerAnalysis {
             for (int i = 0; i < resultArray.size(); i++) {
                 // Deserailize them into GoblintResult objects
                 GoblintResult goblintResult = gson.fromJson(resultArray.get(i), GoblintResult.class);
-                // Add sourcefileURL to object for generationg the position
-                goblintResult.sourcefileURL = this.sourcefileURL;
                 // Convert GoblintResult object to a list of GoblintAnalysisResults
                 results.addAll(goblintResult.convert());
             }
             log.debug("Analysis results read from json");
 
-        } catch (JsonIOException | JsonSyntaxException | FileNotFoundException e) {
+        } catch (JsonIOException | JsonSyntaxException | FileNotFoundException | MalformedURLException e) {
             throw new RuntimeException(e);
         }
 

--- a/src/main/java/GoblintAnalysisResult.java
+++ b/src/main/java/GoblintAnalysisResult.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 
 import magpiebridge.core.AnalysisResult;
 import magpiebridge.core.Kind;
-import magpiebridge.util.SourceCodeReader;
+// import magpiebridge.util.SourceCodeReader;
 
 import org.eclipse.lsp4j.DiagnosticSeverity;
 
@@ -89,13 +89,14 @@ public class GoblintAnalysisResult implements AnalysisResult {
 
     @Override
     public String code() {
-        String code;
-        try {
-            code = SourceCodeReader.getLinesInString(pos);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-        return code;
+        // String code;
+        // try {
+        //     code = SourceCodeReader.getLinesInString(pos);
+        // } catch (Exception e) {
+        //     throw new RuntimeException(e);
+        // }
+        // return code;
+        return null;
     }
 
 }


### PR DESCRIPTION
Instead of trying to find where to end a notification by finding the first ';', GobPie now uses line and column end positions from the JSON output provided by Goblint.
Additionally, the Positions of AnalysisResults get the source file information from JSON instead of using the file that the analysis was stared on as source file because the JSON output has results for several different files, not only the one that triggered the analysis.

Needs to wait until [goblint/analyzer #449](https://github.com/goblint/analyzer/pull/449) is merged.

