### PR TITLE
Analyse files according to compilation database

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,15 +28,24 @@ The project must have:
 Example configuration file `gobpie.json`:
 ```
 {
-    "compilationDatabaseDirPath" : "build", 
-    "goblintConfPath" : "goblint.json",
-    "compilationDBBuildCommands" : ["cmake", "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON", "build"]
+    "goblintConf" : "goblint.json",
+    "files" : ["./build"], 
+    "preAnalyzeCommand" : ["cmake", "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON", "build"]
 }
 ```
 
-* `compilationDatabaseDirPath` - the relative path from project root to the folder containing the project's compilation database (required)
-* `goblintConfPath` - the relative path from project root to the goblint configuration file (required)
-* `compilationDBBuildCommands` - the command for building/updating the compilation database (optional)
+* `goblintConf` - the relative path from project root to the goblint configuration file (required)
+* `files` - the relative paths from project root to the files to be analysed (required)
+* `preAnalyzeCommand` - the command to run before analysing (e.g. command for building/updating the compilation database for some automation) (optional)
+
+Example values for `files`:
+* analyse files according to a compilation database:
+  * `["."]`  (current directory should have the database)
+  * `["./build"]` (build directory should have the database)
+  * `["./build/compile_commands.json"]` (direct path to the database, not its directory)
+* analyse specified file(s) from the project:
+  * `["./01-assert.c"]` (single file for analysis without database)
+  * `["./01-assert.c", "extra.c"]` (multiple files for analysis without database)
 
 ## Developing
 

--- a/Readme.md
+++ b/Readme.md
@@ -17,6 +17,26 @@ code .
 ```
 The *switch name* (shown in the first column of `opam switch`) is the path to the goblint installation.
 
+### Project prerequisites
+
+The project must have:
+1. GobPie configuration file in project root with name "`gobpie.json`"
+2. Goblint configuration file ([see examples](https://github.com/goblint/analyzer/tree/master/conf))
+
+#### Gobpie configuration file
+
+Example configuration file `gobpie.json`:
+```
+{
+    "compilationDatabaseDirPath" : "build", 
+    "goblintConfPath" : "goblint.json",
+    "compilationDBBuildCommands" : ["cmake", "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON", "build"]
+}
+```
+
+* `compilationDatabaseDirPath` - the relative path from project root to the folder containing the project's compilation database (required)
+* `goblintConfPath` - the relative path from project root to the goblint configuration file (required)
+* `compilationDBBuildCommands` - the command for building/updating the compilation database (optional)
 
 ## Developing
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,12 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.14.1</version>
+			<version>2.15.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.14.1</version>
+			<version>2.15.0</version>
 		</dependency>
  </dependencies>
 	<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
 	<artifactId>goblintanalyzer</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<dependencies>
-		 <dependency>
-    		<groupId>com.github.magpiebridge</groupId>
-    		<artifactId>magpiebridge</artifactId>
-    		<version>0.1.2</version>
+		<dependency>
+  			<groupId>com.github.magpiebridge</groupId>
+  			<artifactId>magpiebridge</artifactId>
+ 			<version>0.1.3</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->

--- a/src/main/java/GobPieConfiguration.java
+++ b/src/main/java/GobPieConfiguration.java
@@ -1,0 +1,19 @@
+public class GobPieConfiguration {
+
+    private String compilationDatabaseDirPath = "";
+    private String goblintConfPath = "";
+    private String[] compilationDBBuildCommands;
+
+    public String getCompilationDatabaseDirPath() {
+        return this.compilationDatabaseDirPath;
+    }
+
+    public String getGoblintConfPath() {
+        return this.goblintConfPath;
+    }
+
+    public String[] getCompilationDBBuildCommands() {
+        return this.compilationDBBuildCommands;
+    }
+
+}

--- a/src/main/java/GobPieConfiguration.java
+++ b/src/main/java/GobPieConfiguration.java
@@ -1,19 +1,19 @@
 public class GobPieConfiguration {
 
-    private String compilationDatabaseDirPath = "";
-    private String goblintConfPath = "";
-    private String[] compilationDBBuildCommands;
+    private String   goblintConf = "";
+    private String[] files;
+    private String[] preAnalyzeCommand;
 
-    public String getCompilationDatabaseDirPath() {
-        return this.compilationDatabaseDirPath;
+    public String getGoblintConf() {
+        return this.goblintConf;
     }
 
-    public String getGoblintConfPath() {
-        return this.goblintConfPath;
+    public String[] getFiles() {
+        return this.files;
     }
 
-    public String[] getCompilationDBBuildCommands() {
-        return this.compilationDBBuildCommands;
+    public String[] getPreAnalyzeCommand() {
+        return this.preAnalyzeCommand;
     }
 
 }

--- a/src/main/java/GoblintAnalysis.java
+++ b/src/main/java/GoblintAnalysis.java
@@ -2,7 +2,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.net.MalformedURLException;
 import java.util.*;
 import java.util.concurrent.TimeoutException;
@@ -112,7 +111,7 @@ public class GoblintAnalysis implements ServerAnalysis {
         this.goblintRunCommand = Stream.concat(
                                     Arrays.stream(new String[]{"goblint", "--conf", pathToGoblintConf, "--set", "result", "json-messages", "-o", jsonResult.getAbsolutePath()}), 
                                     Arrays.stream(filesToAnalyze))
-                                    .toArray(size -> (String[]) Array.newInstance(filesToAnalyze.getClass().getComponentType(), size));
+                                    .toArray(String[]::new);
 
         try {
             // run command

--- a/src/main/java/GoblintResult.java
+++ b/src/main/java/GoblintResult.java
@@ -4,60 +4,55 @@ import com.ibm.wala.util.collections.Pair;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
+
 
 public class GoblintResult {
 
-    private List<tag> tags = new ArrayList<>();
-    private String severity;
-    private multipiece multipiece;
+    private Map<String, List<String>> files;
+    private List<Message> messages = new ArrayList<>();
 
-    public static interface tag {
+    static class Message {
 
-        public String toString();
+        private List<tag> tags = new ArrayList<>();
+        private String severity;
+        private multipiece multipiece;
 
-        static class Category implements tag {
-            private List<String> Category = new ArrayList<String>();
+        static interface tag {
 
-            @Override
-            public String toString() {
-                return (Category.size() > 0) ? "[" + String.join(" > ", Category) + "]" : "";
+            public String toString();
+
+            static class Category implements tag {
+                private List<String> Category = new ArrayList<String>();
+
+                @Override
+                public String toString() {
+                    return (Category.size() > 0) ? "[" + String.join(" > ", Category) + "]" : "";
+                }
+
             }
 
-        }
+            static class CWE implements tag {
+                private Integer CWE;
 
-        static class CWE implements tag {
-            private Integer CWE;
-
-            @Override
-            public String toString() {
-                return (CWE != null) ? "[CWE-" + CWE + "]" : "";
+                @Override
+                public String toString() {
+                    return (CWE != null) ? "[CWE-" + CWE + "]" : "";
+                }
             }
         }
-    }
 
-    static class multipiece {
+        static class multipiece {
 
-        private loc loc;
-        private String text;
-        private String group_text;
-        private List<pieces> pieces = new ArrayList<pieces>();
-
-        static class loc {
-
-            private String file;
-            private int line;
-            private int column;
-            private int endLine;
-            private int endColumn;
-
-        }
-
-        static class pieces {
-
-            private String text;
             private loc loc;
+            private String text;
+            private String group_text;
+            private List<pieces> pieces = new ArrayList<pieces>();
 
             static class loc {
 
@@ -66,45 +61,71 @@ public class GoblintResult {
                 private int column;
                 private int endLine;
                 private int endColumn;
+
+            }
+
+            static class pieces {
+
+                private String text;
+                private loc loc;
+
+                static class loc {
+
+                    private String file;
+                    private int line;
+                    private int column;
+                    private int endLine;
+                    private int endColumn;
+                }
             }
         }
-
     }
 
     public List<GoblintAnalysisResult> convert() throws MalformedURLException {
         List<GoblintAnalysisResult> results = new ArrayList<>();
 
-        if (multipiece.group_text == null) {
-            String message = tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " " + multipiece.text;
-            GoblintPosition pos = new GoblintPosition(multipiece.loc.line, multipiece.loc.endLine, multipiece.loc.column - 1, multipiece.loc.endColumn - 1, new File(multipiece.loc.file).toURI().toURL());
-            GoblintAnalysisResult result = new GoblintAnalysisResult(pos, message, severity);
-            results.add(result);
-        } else {
-            List<GoblintAnalysisResult> intermresults = new ArrayList<>();
-            List<multipiece.pieces> pieces = multipiece.pieces;
-            for (multipiece.pieces piece : pieces) {
-                GoblintPosition pos = new GoblintPosition(piece.loc.line, piece.loc.endLine, piece.loc.column - 1, piece.loc.endColumn - 1, new File(piece.loc.file).toURI().toURL());
-                GoblintAnalysisResult result = new GoblintAnalysisResult(pos,
-                        tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " Group: " + multipiece.group_text,
-                        piece.text, severity);
-                intermresults.add(result);
-            }
-            // Add related warnings to all the group elements
-            List<GoblintAnalysisResult> addedRelated = new ArrayList<>();
-            for (GoblintAnalysisResult res1 : intermresults) {
-                List<Pair<Position, String>> related = new ArrayList<>();
-                for (GoblintAnalysisResult res2 : intermresults) {
-                    if (res1 != res2) {
-                        related.add(Pair.make(res2.position(), res2.text()));
-                    }
+        for (Message message : messages) {
+            if (message.multipiece.group_text == null) {
+                String msg = message.tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " " + message.multipiece.text;
+                GoblintPosition pos = new GoblintPosition(message.multipiece.loc.line, message.multipiece.loc.endLine, message.multipiece.loc.column - 1, message.multipiece.loc.endColumn - 1, new File(message.multipiece.loc.file).toURI().toURL());
+                GoblintAnalysisResult result = new GoblintAnalysisResult(pos, msg, message.severity);
+                results.add(result);
+            } else {
+                List<GoblintAnalysisResult> intermresults = new ArrayList<>();
+                List<Message.multipiece.pieces> pieces = message.multipiece.pieces;
+                for (Message.multipiece.pieces piece : pieces) {
+                    GoblintPosition pos = new GoblintPosition(piece.loc.line, piece.loc.endLine, piece.loc.column - 1, piece.loc.endColumn - 1, new File(piece.loc.file).toURI().toURL());
+                    GoblintAnalysisResult result = new GoblintAnalysisResult(pos,
+                            message.tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " Group: " + message.multipiece.group_text,
+                            piece.text, message.severity);
+                    intermresults.add(result);
                 }
-                addedRelated.add(new GoblintAnalysisResult(res1.position(), res1.group_text() + "\n" + res1.text(),
-                        res1.severityStr(), related));
+                // Add related warnings to all the group elements
+                List<GoblintAnalysisResult> addedRelated = new ArrayList<>();
+                for (GoblintAnalysisResult res1 : intermresults) {
+                    List<Pair<Position, String>> related = new ArrayList<>();
+                    for (GoblintAnalysisResult res2 : intermresults) {
+                        if (res1 != res2) {
+                            related.add(Pair.make(res2.position(), res2.text()));
+                        }
+                    }
+                    addedRelated.add(new GoblintAnalysisResult(res1.position(), res1.group_text() + "\n" + res1.text(),
+                            res1.severityStr(), related));
+                }
+                results.addAll(addedRelated);
             }
-            results.addAll(addedRelated);
         }
         return results;
     }
 
+
+    public List<String> getFiles() {
+        Set<String> allFiles = new HashSet<>();
+        for (Entry<String,List<String>> entry : files.entrySet()) {
+            allFiles.add(entry.getKey());
+            allFiles.addAll(entry.getValue());
+        }
+        return new ArrayList<>(allFiles);
+    }
 
 }

--- a/src/main/java/GoblintResult.java
+++ b/src/main/java/GoblintResult.java
@@ -1,8 +1,8 @@
 import com.ibm.wala.cast.tree.CAstSourcePositionMap.Position;
 import com.ibm.wala.util.collections.Pair;
 
+import java.io.File;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -76,14 +76,14 @@ public class GoblintResult {
 
         if (multipiece.group_text == null) {
             String message = tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " " + multipiece.text;
-            GoblintPosition pos = new GoblintPosition(multipiece.loc.line, multipiece.loc.endLine, multipiece.loc.column - 1, multipiece.loc.endColumn - 1, new URL("file:" + multipiece.loc.file));
+            GoblintPosition pos = new GoblintPosition(multipiece.loc.line, multipiece.loc.endLine, multipiece.loc.column - 1, multipiece.loc.endColumn - 1, new File(multipiece.loc.file).toURI().toURL());
             GoblintAnalysisResult result = new GoblintAnalysisResult(pos, message, severity);
             results.add(result);
         } else {
             List<GoblintAnalysisResult> intermresults = new ArrayList<>();
             List<multipiece.pieces> pieces = multipiece.pieces;
             for (multipiece.pieces piece : pieces) {
-                GoblintPosition pos = new GoblintPosition(piece.loc.line, piece.loc.endLine, piece.loc.column - 1, piece.loc.endColumn - 1, new URL("file:" + piece.loc.file));
+                GoblintPosition pos = new GoblintPosition(piece.loc.line, piece.loc.endLine, piece.loc.column - 1, piece.loc.endColumn - 1, new File(piece.loc.file).toURI().toURL());
                 GoblintAnalysisResult result = new GoblintAnalysisResult(pos,
                         tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " Group: " + multipiece.group_text,
                         piece.text, severity);

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -20,7 +20,7 @@ public class Main {
         MagpieServer server = createServer();
         log.info("Server created");
         // launch the server only if there is a goblint conf file present
-        if (new File(System.getProperty("user.dir") + "/" + "goblint.json").exists()) {
+        if (new File(System.getProperty("user.dir") + "/" + "gobpie.json").exists()) {
             server.launchOnStdio();
             log.info("Server launched");
         }
@@ -28,10 +28,8 @@ public class Main {
 
     private static MagpieServer createServer() {
         // set up configuration for MagpieServer
-        ServerConfiguration defaultConfig = new ServerConfiguration();
-        // trigger analysis when file is opened
-        defaultConfig.setDoAnalysisByOpen(true);
-        MagpieServer server = new MagpieServer(defaultConfig);
+        ServerConfiguration serverConfig = new ServerConfiguration();
+        MagpieServer server = new MagpieServer(serverConfig);
         // define language
         String language = "c";
         // add analysis to the MagpieServer

--- a/src/main/java/TagInterfaceAdapter.java
+++ b/src/main/java/TagInterfaceAdapter.java
@@ -12,9 +12,9 @@ public class TagInterfaceAdapter implements JsonDeserializer<Object> {
     public Object deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
         JsonObject jsonObject = jsonElement.getAsJsonObject();
         if (jsonObject.has("Category"))
-            return jsonDeserializationContext.deserialize(jsonObject, GoblintResult.tag.Category.class);
+            return jsonDeserializationContext.deserialize(jsonObject, GoblintResult.Message.tag.Category.class);
         if (jsonObject.has("CWE"))
-            return jsonDeserializationContext.deserialize(jsonObject, GoblintResult.tag.CWE.class);
+            return jsonDeserializationContext.deserialize(jsonObject, GoblintResult.Message.tag.CWE.class);
         return null;
     }
 


### PR DESCRIPTION
GobPie now analyses files according to the compilation database instead of individual opened or saved files.

* There is now a configuration file for GobPie, from which are read the relative paths from project root to:
   * the Goblint conf file;
   * the directory where the compilation database is located.

These two fields are mandatory.
   
The configuration file also includes a field to get the commands for building a compilation database. This feature was added because if compilation database creation is not done automatically, it is pretty annoying-confusing when the analysis does not run on the newly created files and the user should build the compilation database manually each time they create a new file (not too user-friendly). This approach is not optimal, but for now, it is better than nothing.

* Instead of checking if the Goblint conf file with the name `goblint.json` exists in the project root, the existence of the GobPie conf file with the name `gobpie.json` is checked. Goblint configuration file can now be wherever - it just needs to exist somewhere in the project and its path must be specified in the gobpie conf.

* The readMe is updated with the documentation of prerequisites for the project-to-be-analysed
* The log4j got updated to a non-vulnerable version
* There is a corresponding version of the [demoproject](https://github.com/karoliineh/GobPie-DemoProject/pull/1) also available