### PR TITLE
Handle results with empty locations

### DIFF
--- a/src/main/java/analysis/GoblintMessages.java
+++ b/src/main/java/analysis/GoblintMessages.java
@@ -78,18 +78,13 @@ public class GoblintMessages {
         List<GoblintAnalysisResult> results = new ArrayList<>();
 
             if (multipiece.group_text == null) {
-                String msg = tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " " + multipiece.text;
-                GoblintPosition pos = new GoblintPosition(multipiece.loc.line, multipiece.loc.endLine, multipiece.loc.column - 1, multipiece.loc.endColumn - 1, new File(multipiece.loc.file).toURI().toURL());
-                GoblintAnalysisResult result = new GoblintAnalysisResult(pos, msg, severity);
+                GoblintAnalysisResult result = createGoblintAnalysisResult();
                 results.add(result);
             } else {
                 List<GoblintAnalysisResult> intermresults = new ArrayList<>();
                 List<multipiece.pieces> pieces = multipiece.pieces;
                 for (multipiece.pieces piece : pieces) {
-                    GoblintPosition pos = new GoblintPosition(piece.loc.line, piece.loc.endLine, piece.loc.column - 1, piece.loc.endColumn - 1, new File(piece.loc.file).toURI().toURL());
-                    GoblintAnalysisResult result = new GoblintAnalysisResult(pos,
-                            tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " Group: " + multipiece.group_text,
-                            piece.text, severity);
+                    GoblintAnalysisResult result = createGoblintAnalysisResult(piece);
                     intermresults.add(result);
                 }
                 // Add related warnings to all the group elements
@@ -106,7 +101,27 @@ public class GoblintMessages {
                 }
                 results.addAll(addedRelated);
         }
+
         return results;
+    }
+
+
+    public GoblintAnalysisResult createGoblintAnalysisResult() throws MalformedURLException {
+        GoblintPosition pos = multipiece.loc == null 
+                              ? new GoblintPosition(1, 1, 1, new File("").toURI().toURL()) 
+                              : new GoblintPosition(multipiece.loc.line, multipiece.loc.endLine, multipiece.loc.column - 1, multipiece.loc.endColumn - 1, new File(multipiece.loc.file).toURI().toURL());
+        String msg = tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " " + multipiece.text;
+        return new GoblintAnalysisResult(pos, msg, severity);
+    }
+
+
+    public GoblintAnalysisResult createGoblintAnalysisResult(multipiece.pieces piece) throws MalformedURLException {
+        GoblintPosition pos = multipiece.loc == null
+                              ? new GoblintPosition(1, 1, 5, new File("").toURI().toURL())
+                              : new GoblintPosition(piece.loc.line, piece.loc.endLine, piece.loc.column - 1, piece.loc.endColumn - 1, new File(piece.loc.file).toURI().toURL());
+        return new GoblintAnalysisResult(pos,
+                    tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " Group: " + multipiece.group_text,
+                    piece.text, severity);
     }
 
 

--- a/src/main/java/analysis/GoblintMessages.java
+++ b/src/main/java/analysis/GoblintMessages.java
@@ -117,7 +117,7 @@ public class GoblintMessages {
 
     public GoblintAnalysisResult createGoblintAnalysisResult(multipiece.pieces piece) throws MalformedURLException {
         GoblintPosition pos = multipiece.loc == null
-                              ? new GoblintPosition(1, 1, 5, new File("").toURI().toURL())
+                              ? new GoblintPosition(1, 1, 1, new File("").toURI().toURL())
                               : new GoblintPosition(piece.loc.line, piece.loc.endLine, piece.loc.column - 1, piece.loc.endColumn - 1, new File(piece.loc.file).toURI().toURL());
         return new GoblintAnalysisResult(pos,
                     tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " Group: " + multipiece.group_text,


### PR DESCRIPTION
The fix for #21.

> Depending on what Magpie allows, there are a few choices:
> 1. Completely ignore locationless messages.
> 2. If possible, output the message such that it's in the warnings list, but nowhere in the analyzed source code.
> 3. If the previous is not possible, then alternative might be to attach some location to it to have it show up somewhere.

The solution I did is something between options 2 and 3. I first tried with an empty position, but at least `sourcefileURL` must be not `null` in the position, otherwise, MagpieBridge will run into exception. When adding just the project source directory URL for `sourcefileURL`, the message will be completely ignored (only the messages with line numbers present will be shown). Then I added line and column numbers with values `1`, which gives a solution that shows the warning in the warning list, but nowhere in the analyzed source file (2), however it still has to have _some_ location attached to it (3).

![image](https://user-images.githubusercontent.com/44437975/157656383-6459d3b5-223a-42e3-a659-0c203446c4b0.png)

The only problem is that the warning in the warnings list is not connected to any file, because as the `loc` field is completely empty, I cannot get the filename from there (from `loc.file`). Therefore one has to guess for which file the warning is connected. The other problem is, that when clicking on the warning, you get an error pop-up _Unable to open 'DemoProject': File is a directory._ from VSCode, because the position has the project directory as the `sourcefileURL`.

If the `loc.file` field would be always available, this issue with the result not being connected to a file would be solved, but it would bring another problem: some line and column numbers must still be given. Therefore I should put `1` for their values as in the current solution so that the warnings without locations would be always shown on the first line of the file. This _might_ cause problems when the file is empty, but I guess a file in VSCode always has at least one line in it so it shouldn't actually be a problem? Edit: also I guess there are no warnings in an empty file anyways? So maybe it is possible to make the `loc.file` to never be empty?