### PR TITLE
Goblint server automatic restart

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -53,7 +53,7 @@ public class Main {
 
         // connect GoblintClient
         GoblintClient goblintClient = new GoblintClient(magpieServer);
-        boolean goblintClientConnected = goblintClient.connectGoblitClient();
+        boolean goblintClientConnected = goblintClient.connectGoblintClient();
         if (!goblintClientConnected) return null;
 
         // add analysis to the MagpieServer

--- a/src/main/java/goblintserver/GobPieConfiguration.java
+++ b/src/main/java/goblintserver/GobPieConfiguration.java
@@ -3,15 +3,10 @@ package goblintserver;
 public class GobPieConfiguration {
 
     private String   goblintConf = "";
-    private String[] files;
     private String[] preAnalyzeCommand;
 
     public String getGoblintConf() {
         return this.goblintConf;
-    }
-
-    public String[] getFiles() {
-        return this.files;
     }
 
     public String[] getPreAnalyzeCommand() {

--- a/src/main/java/goblintserver/GoblintClient.java
+++ b/src/main/java/goblintserver/GoblintClient.java
@@ -47,7 +47,7 @@ public class GoblintClient {
      * @return True if connection was started successfully, false otherwise.
      */
 
-    public boolean connectGoblitClient() {
+    public boolean connectGoblintClient() {
         try {
             // connect to the goblint socket
             address = UnixDomainSocketAddress.of(Path.of(goblintSocketName));

--- a/src/main/java/goblintserver/GoblintServer.java
+++ b/src/main/java/goblintserver/GoblintServer.java
@@ -2,7 +2,6 @@ package goblintserver;
 
 import java.util.*;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Stream;
 import java.io.*;
 import java.nio.file.*;
 
@@ -161,21 +160,20 @@ public class GoblintServer {
             this.preAnalyzeCommand = gobpieConfiguration.getPreAnalyzeCommand();
 
             // Check if all required parameters have been set
-            if (gobpieConfiguration.getGoblintConf().equals("") || gobpieConfiguration.getFiles() == null || gobpieConfiguration.getFiles().length < 1) {
+            if (gobpieConfiguration.getGoblintConf().equals("")) {
                 log.debug("Configuration parameters missing from GobPie configuration file");
                 this.magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Configuration parameters missing from GobPie configuration file."));
                 return false;
             }
 
             // Construct command to run Goblint Server 
-            // by concatenating the run command with files to analyse (read from GobPie conf)
-            this.goblintRunCommand = Stream.concat(
-                            Arrays.stream(new String[]{"goblint", "--conf", new File(gobpieConfiguration.getGoblintConf()).getAbsolutePath(),
+            // Files to analyse must be defined in goblint conf
+            this.goblintRunCommand = Arrays.stream(new String[]{
+                                    "goblint", "--conf", new File(gobpieConfiguration.getGoblintConf()).getAbsolutePath(),
                                     "--enable", "server.enabled",
                                     "--enable", "server.reparse",
                                     "--set", "server.mode", "unix",
-                                    "--set", "server.unix-socket", new File(goblintSocket).getAbsolutePath()}),
-                            Arrays.stream(gobpieConfiguration.getFiles()))
+                                    "--set", "server.unix-socket", new File(goblintSocket).getAbsolutePath()})
                     .toArray(String[]::new);
 
             log.debug("GobPie configuration read from json");

--- a/src/main/java/goblintserver/GoblintServer.java
+++ b/src/main/java/goblintserver/GoblintServer.java
@@ -24,15 +24,23 @@ public class GoblintServer {
 
     private String gobPieConf = "gobpie.json";
     private String goblintSocket = "goblint.sock";
+    private String goblintConf;
 
     private String[] preAnalyzeCommand;
     private String[] goblintRunCommand;
+
+    private StartedProcess goblintRunProcess;
 
     private final Logger log = LogManager.getLogger(GoblintClient.class);
 
 
     public GoblintServer(MagpieServer magpieServer) {
         this.magpieServer = magpieServer;
+    }
+
+
+    public String getGoblintConf() {
+        return goblintConf;
     }
 
 
@@ -56,9 +64,9 @@ public class GoblintServer {
             // run command to start goblint
             log.info("Goblint run with command: " + String.join(" ", goblintRunCommand));
 
-            StartedProcess commandRunProcess = runCommand(new File(System.getProperty("user.dir")), goblintRunCommand);
+            goblintRunProcess = runCommand(new File(System.getProperty("user.dir")), goblintRunCommand);
 
-            if (commandRunProcess.getFuture().isDone() && commandRunProcess.getProcess().exitValue() != 0) {
+            if (goblintRunProcess.getFuture().isDone() && goblintRunProcess.getProcess().exitValue() != 0) {
                 magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Goblint exited with an error."));
                 log.error("Goblint exited with an error.");
                 return false;
@@ -89,14 +97,25 @@ public class GoblintServer {
     }
 
 
-    // public void stopGoblintServer() {
-    //     try {
-    //         Files.deleteIfExists(socketPath);
-    //     } catch (IOException e) {
-    //         // TODO Auto-generated catch block
-    //         e.printStackTrace();
-    //     }
-    // }
+    /**
+    * Method to stop the Goblint server.
+    */
+
+    public void stopGoblintServer() {
+        goblintRunProcess.getProcess().destroy();
+    }
+
+
+    /**
+     * Method to restart the Goblint server.
+     *
+     * @return True if new server was started successfully, false otherwise.
+     */
+
+    public boolean restartGoblintServer() {
+        stopGoblintServer();
+        return startGoblintServer();
+    }
 
 
     /**
@@ -109,18 +128,16 @@ public class GoblintServer {
 
     public StartedProcess runCommand(File dirPath, String[] command) throws IOException, InterruptedException, InvalidExitValueException, TimeoutException {
         ProcessListener listener = new ProcessListener() {
-            public void afterFinish(Process process, ProcessResult result) {
-                magpieServer.forwardMessageToClient(new MessageParams(MessageType.Info, "Goblint server finished."));
-                log.info("Goblint server finished.");
-              }
 
             public void afterStop(Process process) {
-                if (process.exitValue() != 0) {
-                    magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Goblint server exited due to an error."));
-                    log.error("Goblint server exited due to an error.");
-                } else {
+                if (process.exitValue() == 0) {
                     magpieServer.forwardMessageToClient(new MessageParams(MessageType.Info, "Goblint server has stopped."));
                     log.info("Goblint server has stopped.");
+                } else if (process.exitValue() == 143) {
+                    log.info("Goblint server has been killed.");
+                } else {
+                    magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Goblint server exited due to an error."));
+                    log.error("Goblint server exited due to an error.");
                 }
             }
         };
@@ -158,9 +175,10 @@ public class GoblintServer {
             // Convert json object to GobPieConfiguration object
             GobPieConfiguration gobpieConfiguration = gson.fromJson(jsonObject, GobPieConfiguration.class);
             this.preAnalyzeCommand = gobpieConfiguration.getPreAnalyzeCommand();
+            this.goblintConf = gobpieConfiguration.getGoblintConf();
 
             // Check if all required parameters have been set
-            if (gobpieConfiguration.getGoblintConf().equals("")) {
+            if (goblintConf.equals("")) {
                 log.debug("Configuration parameters missing from GobPie configuration file");
                 this.magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Configuration parameters missing from GobPie configuration file."));
                 return false;
@@ -169,7 +187,7 @@ public class GoblintServer {
             // Construct command to run Goblint Server 
             // Files to analyse must be defined in goblint conf
             this.goblintRunCommand = Arrays.stream(new String[]{
-                                    "goblint", "--conf", new File(gobpieConfiguration.getGoblintConf()).getAbsolutePath(),
+                                    "goblint", "--conf", new File(goblintConf).getAbsolutePath(),
                                     "--enable", "server.enabled",
                                     "--enable", "server.reparse",
                                     "--set", "server.mode", "unix",
@@ -177,8 +195,6 @@ public class GoblintServer {
                     .toArray(String[]::new);
 
             log.debug("GobPie configuration read from json");
-        } catch (JsonIOException | JsonSyntaxException e) {
-            throw new RuntimeException(e);
         } catch (FileNotFoundException e) {
             this.magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Could not locate GobPie configuration file. " + e.getMessage()));
             return false;


### PR DESCRIPTION
Closes #23 and #24

* Files are now read from Goblint conf instead of GobPie conf.
* Goblint server is restarted when the Goblint configuration file is modified.

The latter is implemented using `FileAlterationObserver` because this allows tracking the `fileChanged `event. The `WatchService`, that was used previously for determining whether the socket file has been made and waiting until it is, was not good for this case, because it expects a while loop, which halts the process until something happens, so it should've been done in a separate thread, but synchronizing the threads later would have been a headache. `FileAlterationObserver` lets one check whether any files were changed compared to the previous time the file was encountered and if so, take action without needing to halt and wait for an event to happen.