### PR TITLE
Better error handling

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,3 +1,6 @@
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.nio.file.*;
 
@@ -6,16 +9,18 @@ import magpiebridge.core.ServerAnalysis;
 import magpiebridge.core.ServerConfiguration;
 import magpiebridge.core.ToolAnalysis;
 
+import com.google.gson.*;
+
 import analysis.GoblintAnalysis;
-import goblintserver.GobPieException;
-import goblintserver.GoblintClient;
-import goblintserver.GoblintServer;
+import goblintserver.*;
 
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import static goblintserver.GobPieExceptionType.*;
 
 public class Main {
 
@@ -27,22 +32,20 @@ public class Main {
 
         try {
             createMagpieServer();
-            launchMagpieServer();
+            addAnalysis();
+            magpieServer.doAnalysis("c", true);
         } catch (GobPieException e) {
-            launchMagpieServer();
-            String message = "Unable to start GobPie extension: " + e.getMessage();
-            magpieServer.forwardMessageToClient(
-                new MessageParams(MessageType.Error, message + " Please check the output terminal of GobPie extension for more information.")
-            );
-            if (e.getCause() == null) log.error(message);
-            else log.error(message + " Cause: " + e.getCause().getMessage());
+            String message = e.getMessage();
+            String terminalMessage;
+            if (e.getCause() == null) terminalMessage = message;
+            else terminalMessage = message + " Cause: " + e.getCause().getMessage();
+            forwardErrorMessageToClient(message, terminalMessage);
             switch (e.getType()) {
                 case GOBLINT_EXCEPTION:
                     break;
                 case GOBPIE_EXCEPTION:
                     break;
                 case GOBPIE_CONF_EXCEPTION:
-                    waitForGobPieConf();
                     break;
             }
         }
@@ -51,30 +54,45 @@ public class Main {
 
 
     /**
-     * Method for creating MagpieBridge server. 
-     * 
-     * Only if the gobpie configuration file exists in the project root, 
-     * GoblintServer, GoblintClient and the GoblintAnalysis class are created
-     * for the extension to work as it should.
-     * 
-     * Otherwise just a server without an analysis added to it is created. 
-     * This is due to the extension having to start something in able to not just crash.
-     *
-     * @throws GobPieException if something goes wrong in any of the steps.
+     * Method for creating and launching MagpieBridge server.
      */
 
-    private static void createMagpieServer() throws GobPieException {
+    private static void createMagpieServer()  {
         
         // set up configuration for MagpieServer
         ServerConfiguration serverConfig = new ServerConfiguration();
         serverConfig.setDoAnalysisByFirstOpen(false);
         magpieServer = new MagpieServer(serverConfig);
 
+        // launch magpieServer
+        magpieServer.launchOnStdio();
+        log.info("MagpieBridge server launched.");
+
+    }
+
+
+    /**
+     * Method for creating and adding GoblintAnalysis to MagpieBridge server 
+     * and doing the initial analysis.
+     * 
+     * Creates GoblintServer, GoblintClient and the GoblintAnalysis classes.
+     * 
+     * @throws GobPieException if something goes wrong with creating any of the classes:
+     *          <ul>
+     *              <li>GoblintServer;</li>
+     *              <li>GoblintClient.</li>
+     *          </ul>
+     */
+
+    private static void addAnalysis() {
         // define language
         String language = "c";
 
+        // read gobpie configuration file
+        GobPieConfiguration gobpieConfiguration = readGobPieConfiguration();
+
         // start GoblintServer
-        GoblintServer goblintServer = new GoblintServer(gobPieConfFileName);
+        GoblintServer goblintServer = new GoblintServer(gobpieConfiguration.getGoblintConf(), magpieServer);
         goblintServer.startGoblintServer();
 
         // connect GoblintClient
@@ -82,27 +100,84 @@ public class Main {
         goblintClient.connectGoblintClient();
 
         // add analysis to the MagpieServer
-        ServerAnalysis serverAnalysis = new GoblintAnalysis(magpieServer, goblintServer, goblintClient);
+        ServerAnalysis serverAnalysis = new GoblintAnalysis(magpieServer, goblintServer, goblintClient, gobpieConfiguration);
         Either<ServerAnalysis, ToolAnalysis> analysis = Either.forLeft(serverAnalysis);
         magpieServer.addAnalysis(analysis, language);
-
     }
 
 
-    /**
-     * Method for launching MagpieBridge server and doing the initial analysis.
+   /**
+     * Method for reading GobPie configuration.
+     * 
+     * Waits for the Gobpie configuration file to be created if one is not present in the project root.
+     * Checks if all the required parameters are present in the configuration and 
+     * if not, waits for the file to be changed and reparses it until the user gives the parameters.
+     *
+     * @return GobPieConfiguration object.
      */
 
-    private static void launchMagpieServer() {
-        magpieServer.launchOnStdio();
-        log.info("MagpieBridge server launched.");
-        magpieServer.doAnalysis("c", true);      
+    private static GobPieConfiguration readGobPieConfiguration() {
+
+        // If gobpie configuration is not present, wait for it to be created
+        if (!new File(System.getProperty("user.dir") + "/" + "gobpie.json").exists()) {
+            String message = "GobPie configuration file is not found in the project root.";
+            String terminalMessage = message + "\nPlease add GobPie configuration file into the project root.";
+            forwardErrorMessageToClient(message, terminalMessage);
+            waitForGobPieConf();
+        }
+
+        // Parse the configuration file
+        GobPieConfiguration gobpieConfiguration = parseGobPieConf();
+           
+        // Check if all required parameters have been set
+        // If not, wait for change and reparse
+        String goblintConf = gobpieConfiguration.getGoblintConf();
+        while (goblintConf == null || goblintConf.equals("")) {
+            String message = "goblintConf parameter missing from GobPie configuration file.";
+            String terminalMessage = message + "\nPlease add Goblint configuration file location into GobPie configuration as a parameter with name \"goblintConf\".";
+            forwardErrorMessageToClient(message, terminalMessage);
+            waitForGobPieConf();
+            gobpieConfiguration = parseGobPieConf();
+            goblintConf = gobpieConfiguration.getGoblintConf();
+        }
+        
+        return gobpieConfiguration;
+
+        
     }
 
 
     /**
-     * Method for waiting until GobPie configuration file is created or modified to satisfy the requirements
-     * and then restarting the server so that analyses can be run.
+     * Method for parsing GobPie configuration.
+     * Deserializes json to GobPieConfiguration object.
+     * 
+     * @return GobPieConfiguration object.
+     * @throws GobPieException is thrown if
+     *          <ul>
+     *              <li>gobpie conf cannot be found to be read from;</li>
+     *              <li>gobpie conf json syntax is wrong.</li>
+     *          </ul>
+     */
+
+    private static GobPieConfiguration parseGobPieConf() {
+        try {
+            log.debug("Reading GobPie configuration from json");
+            Gson gson = new GsonBuilder().create();
+            // Read json object
+            JsonObject jsonObject = JsonParser.parseReader(new FileReader(gobPieConfFileName)).getAsJsonObject();
+            // Convert json object to GobPieConfiguration object
+            log.debug("GobPie configuration read from json");
+            return gson.fromJson(jsonObject, GobPieConfiguration.class);
+        } catch (FileNotFoundException e) {
+            throw new GobPieException("Could not locate GobPie configuration file.", e, GOBPIE_CONF_EXCEPTION);
+        } catch (JsonSyntaxException e) {
+            throw new GobPieException("Gobpie configuration file syntax is wrong.", e, GOBPIE_CONF_EXCEPTION);
+        }
+    }
+
+
+    /**
+     * Method for waiting until GobPie configuration file is created or modified to satisfy the requirements.
      */
 
     private static void waitForGobPieConf() {
@@ -112,22 +187,35 @@ public class Main {
         try {
             watchService = FileSystems.getDefault().newWatchService();
             Path path = Paths.get(System.getProperty("user.dir"));
-            path.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
+            path.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
             WatchKey key;
             while ((key = watchService.take()) != null) {
                 for (WatchEvent<?> event : key.pollEvents()) {
                     if (((Path) event.context()).equals(Paths.get(gobPieConfFileName))) {
-                        magpieServer.exit();
-                        break;
+                        return;
                     }
                 }
                 key.reset();
             }
         } catch (IOException | InterruptedException e) {
-            new MessageParams(MessageType.Error, "Restarting GobPie extension failed. Please check the output terminal of GobPie extension for more information.");
-            log.error("Restarting GobPie extension failed: " + e.getMessage());
+            String message = "Waiting for GobPie configuration file failed.";
+            forwardErrorMessageToClient(message, message + e.getMessage());
         } 
 
+   }
+
+
+    /**
+     * Method for forwarding Error messages to MagpieServer.
+     * @param popUpMessage The message shown on the pop-up message.
+     * @param terminalMessage The message shown in the terminal.
+     */
+
+   private static void forwardErrorMessageToClient(String popUpMessage, String terminalMessage) {
+        magpieServer.forwardMessageToClient(
+            new MessageParams(MessageType.Error, "Unable to start GobPie extension: " + popUpMessage + " Please check the output terminal of GobPie extension for more information.")
+        );
+        log.error(terminalMessage);
    }
 
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,4 +1,6 @@
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.*;
 
 import magpiebridge.core.MagpieServer;
 import magpiebridge.core.ServerAnalysis;
@@ -10,58 +12,128 @@ import goblintserver.GoblintClient;
 import goblintserver.GoblintServer;
 
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class Main {
 
+    private static final String gobPieConfFileName = "gobpie.json";
     private static final Logger log = LogManager.getLogger(Main.class);
+    private static MagpieServer magpieServer;
 
     public static void main(String... args) {
 
-        // launch the server only if there is a GobPie conf file present
-        if (new File(System.getProperty("user.dir") + "/" + "gobpie.json").exists()) {
+        int exit = createMagpieServer();
+        launchMagpieServer();
 
-            MagpieServer magpieServer = createMagpieServer();
-
-            if (magpieServer == null) {
-                log.info("Unable to launch MagpieBridge.");
-            } else {
-                magpieServer.launchOnStdio();
-                log.info("MagpieBridge server launched.");
-                magpieServer.doAnalysis("c", true);
+        if (exit != 0) {
+            magpieServer.forwardMessageToClient(
+                new MessageParams(MessageType.Error, "GobPie extension is unable to analyse the code. Please check the output terminal of GobPie extension for more information."));
+            switch (exit) {
+                case 1:
+                    log.error("Unable to fully start GobPie extension: Starting Goblint Server failed.");
+                case 2:
+                    log.error("Unable to fully start GobPie extension: Connecting Goblint Client to Goblint Server failed.");
+                case 3: 
+                    log.error("Unable to fully start GobPie extension: GobPie configuration file is missing.");
+                    waitForGobPieConf();
             }
+
         }
     }
 
 
-    private static MagpieServer createMagpieServer() {
+    /**
+     * Method for creating MagpieBridge server. 
+     * 
+     * Only if the gobpie configuration file exists in the project root, 
+     * GoblintServer, GoblintClient and the GoblintAnalysis class are created
+     * for the extension to work as it should.
+     * 
+     * Otherwise just a server without an analysis added to it is created. 
+     * This is due to the extension having to start something in able to not just crash.
+     *
+     * @return exit value:
+     *          0 - if Goblint Server is created and successfully connected to MagPieBridge
+     *          1 - if Goblint Server was not started successfully
+     *          2 - if Goblint Client could not connect to Goblint Server
+     *          3 - if GobPie configuration file was missing and running Goblint Server was not possible
+     */
 
+    private static int createMagpieServer() {
+        
         // set up configuration for MagpieServer
         ServerConfiguration serverConfig = new ServerConfiguration();
         serverConfig.setDoAnalysisByFirstOpen(false);
-        MagpieServer magpieServer = new MagpieServer(serverConfig);
+        magpieServer = new MagpieServer(serverConfig);
 
-        // define language
-        String language = "c";
+        // try and create Goblint server only if there is a GobPie conf file present
+        if (new File(System.getProperty("user.dir") + "/" + gobPieConfFileName).exists()) {
+            // define language
+            String language = "c";
 
-        // start GoblintServer
-        GoblintServer goblintServer = new GoblintServer(magpieServer);
-        boolean gobServerStarted = goblintServer.startGoblintServer();
-        if (!gobServerStarted) return null;
+            // start GoblintServer
+            GoblintServer goblintServer = new GoblintServer(magpieServer, gobPieConfFileName);
+            boolean gobServerStarted = goblintServer.startGoblintServer();
+            if (!gobServerStarted) return 1;
 
-        // connect GoblintClient
-        GoblintClient goblintClient = new GoblintClient(magpieServer);
-        boolean goblintClientConnected = goblintClient.connectGoblintClient();
-        if (!goblintClientConnected) return null;
+            // connect GoblintClient
+            GoblintClient goblintClient = new GoblintClient(magpieServer);
+            boolean goblintClientConnected = goblintClient.connectGoblintClient();
+            if (!goblintClientConnected) return 2;
 
-        // add analysis to the MagpieServer
-        ServerAnalysis serverAnalysis = new GoblintAnalysis(magpieServer, goblintServer, goblintClient);
-        Either<ServerAnalysis, ToolAnalysis> analysis = Either.forLeft(serverAnalysis);
-        magpieServer.addAnalysis(analysis, language);
+            // add analysis to the MagpieServer
+            ServerAnalysis serverAnalysis = new GoblintAnalysis(magpieServer, goblintServer, goblintClient);
+            Either<ServerAnalysis, ToolAnalysis> analysis = Either.forLeft(serverAnalysis);
+            magpieServer.addAnalysis(analysis, language);
 
-        return magpieServer;
+            return 0;
+        } 
+        
+        return 3;
     }
+
+
+    /**
+     * Method for launching MagpieBridge server and doing the initial analysis.
+     */
+
+    private static void launchMagpieServer() {
+        magpieServer.launchOnStdio();
+        log.info("MagpieBridge server launched.");
+        magpieServer.doAnalysis("c", true);      
+    }
+
+
+    /**
+     * Method for waiting until GobPie configuration file is created
+     * and then restarting the server so that analyses can be run.
+     */
+
+    private static void waitForGobPieConf() {
+
+        // wait until GobPie configuration file is created before continuing
+        WatchService watchService;
+        try {
+            watchService = FileSystems.getDefault().newWatchService();
+            Path path = Paths.get(System.getProperty("user.dir"));
+            path.register(watchService, StandardWatchEventKinds.ENTRY_CREATE );
+            WatchKey key;
+            while ((key = watchService.take()) != null) {
+                for (WatchEvent<?> event : key.pollEvents()) {
+                    if (((Path) event.context()).equals(Paths.get(gobPieConfFileName))) {
+                        magpieServer.exit();
+                        break;
+                    }
+                }
+                key.reset();
+            }
+        } catch (IOException | InterruptedException e) {
+            log.error("Restarting GobPie extension failed: " + e.getMessage());
+        } 
+
+   }
 
 }

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,4 +1,3 @@
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 
@@ -8,6 +7,7 @@ import magpiebridge.core.ServerConfiguration;
 import magpiebridge.core.ToolAnalysis;
 
 import analysis.GoblintAnalysis;
+import goblintserver.GobPieException;
 import goblintserver.GoblintClient;
 import goblintserver.GoblintServer;
 
@@ -25,23 +25,28 @@ public class Main {
 
     public static void main(String... args) {
 
-        int exit = createMagpieServer();
-        launchMagpieServer();
-
-        if (exit != 0) {
+        try {
+            createMagpieServer();
+            launchMagpieServer();
+        } catch (GobPieException e) {
+            launchMagpieServer();
+            String message = "Unable to start GobPie extension: " + e.getMessage();
             magpieServer.forwardMessageToClient(
-                new MessageParams(MessageType.Error, "GobPie extension is unable to analyse the code. Please check the output terminal of GobPie extension for more information."));
-            switch (exit) {
-                case 1:
-                    log.error("Unable to fully start GobPie extension: Starting Goblint Server failed.");
-                case 2:
-                    log.error("Unable to fully start GobPie extension: Connecting Goblint Client to Goblint Server failed.");
-                case 3: 
-                    log.error("Unable to fully start GobPie extension: GobPie configuration file is missing.");
+                new MessageParams(MessageType.Error, message + " Please check the output terminal of GobPie extension for more information.")
+            );
+            if (e.getCause() == null) log.error(message);
+            else log.error(message + " Cause: " + e.getCause().getMessage());
+            switch (e.getType()) {
+                case GOBLINT_EXCEPTION:
+                    break;
+                case GOBPIE_EXCEPTION:
+                    break;
+                case GOBPIE_CONF_EXCEPTION:
                     waitForGobPieConf();
+                    break;
             }
-
         }
+
     }
 
 
@@ -60,39 +65,32 @@ public class Main {
      *          1 - if Goblint Server was not started successfully
      *          2 - if Goblint Client could not connect to Goblint Server
      *          3 - if GobPie configuration file was missing and running Goblint Server was not possible
+     * @throws GobPieException
      */
 
-    private static int createMagpieServer() {
+    private static void createMagpieServer() throws GobPieException {
         
         // set up configuration for MagpieServer
         ServerConfiguration serverConfig = new ServerConfiguration();
         serverConfig.setDoAnalysisByFirstOpen(false);
         magpieServer = new MagpieServer(serverConfig);
 
-        // try and create Goblint server only if there is a GobPie conf file present
-        if (new File(System.getProperty("user.dir") + "/" + gobPieConfFileName).exists()) {
-            // define language
-            String language = "c";
+        // define language
+        String language = "c";
 
-            // start GoblintServer
-            GoblintServer goblintServer = new GoblintServer(magpieServer, gobPieConfFileName);
-            boolean gobServerStarted = goblintServer.startGoblintServer();
-            if (!gobServerStarted) return 1;
+        // start GoblintServer
+        GoblintServer goblintServer = new GoblintServer(gobPieConfFileName);
+        goblintServer.startGoblintServer();
 
-            // connect GoblintClient
-            GoblintClient goblintClient = new GoblintClient(magpieServer);
-            boolean goblintClientConnected = goblintClient.connectGoblintClient();
-            if (!goblintClientConnected) return 2;
+        // connect GoblintClient
+        GoblintClient goblintClient = new GoblintClient();
+        goblintClient.connectGoblintClient();
 
-            // add analysis to the MagpieServer
-            ServerAnalysis serverAnalysis = new GoblintAnalysis(magpieServer, goblintServer, goblintClient);
-            Either<ServerAnalysis, ToolAnalysis> analysis = Either.forLeft(serverAnalysis);
-            magpieServer.addAnalysis(analysis, language);
+        // add analysis to the MagpieServer
+        ServerAnalysis serverAnalysis = new GoblintAnalysis(magpieServer, goblintServer, goblintClient);
+        Either<ServerAnalysis, ToolAnalysis> analysis = Either.forLeft(serverAnalysis);
+        magpieServer.addAnalysis(analysis, language);
 
-            return 0;
-        } 
-        
-        return 3;
     }
 
 
@@ -119,7 +117,7 @@ public class Main {
         try {
             watchService = FileSystems.getDefault().newWatchService();
             Path path = Paths.get(System.getProperty("user.dir"));
-            path.register(watchService, StandardWatchEventKinds.ENTRY_CREATE );
+            path.register(watchService, StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_MODIFY);
             WatchKey key;
             while ((key = watchService.take()) != null) {
                 for (WatchEvent<?> event : key.pollEvents()) {
@@ -131,6 +129,7 @@ public class Main {
                 key.reset();
             }
         } catch (IOException | InterruptedException e) {
+            new MessageParams(MessageType.Error, "Restarting GobPie extension failed. Please check the output terminal of GobPie extension for more information.");
             log.error("Restarting GobPie extension failed: " + e.getMessage());
         } 
 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -60,12 +60,7 @@ public class Main {
      * Otherwise just a server without an analysis added to it is created. 
      * This is due to the extension having to start something in able to not just crash.
      *
-     * @return exit value:
-     *          0 - if Goblint Server is created and successfully connected to MagPieBridge
-     *          1 - if Goblint Server was not started successfully
-     *          2 - if Goblint Client could not connect to Goblint Server
-     *          3 - if GobPie configuration file was missing and running Goblint Server was not possible
-     * @throws GobPieException
+     * @throws GobPieException if something goes wrong in any of the steps.
      */
 
     private static void createMagpieServer() throws GobPieException {
@@ -106,7 +101,7 @@ public class Main {
 
 
     /**
-     * Method for waiting until GobPie configuration file is created
+     * Method for waiting until GobPie configuration file is created or modified to satisfy the requirements
      * and then restarting the server so that analyses can be run.
      */
 

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -27,6 +27,7 @@ import org.zeroturnaround.exec.InvalidExitValueException;
 import org.zeroturnaround.exec.ProcessExecutor;
 import org.zeroturnaround.exec.ProcessResult;
 
+import goblintserver.GobPieException;
 import goblintserver.GoblintClient;
 import goblintserver.GoblintServer;
 import goblintserver.Request;
@@ -219,8 +220,13 @@ public class GoblintAnalysis implements ServerAnalysis {
         observer.addListener(new FileAlterationListenerAdaptor() {        
             @Override
             public void onFileChange(File file) {
-                goblintServer.restartGoblintServer();
-                goblintClient.connectGoblintClient();
+                try {
+                    goblintServer.restartGoblintServer();
+                    goblintClient.connectGoblintClient();
+                } catch (GobPieException e) {
+                    // TODO Auto-generated catch block
+                    e.printStackTrace();
+                }
             }
         });
         

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -27,10 +27,7 @@ import org.zeroturnaround.exec.InvalidExitValueException;
 import org.zeroturnaround.exec.ProcessExecutor;
 import org.zeroturnaround.exec.ProcessResult;
 
-import goblintserver.GobPieException;
-import goblintserver.GoblintClient;
-import goblintserver.GoblintServer;
-import goblintserver.Request;
+import goblintserver.*;
 
 
 public class GoblintAnalysis implements ServerAnalysis {
@@ -38,15 +35,17 @@ public class GoblintAnalysis implements ServerAnalysis {
     private final MagpieServer magpieServer;
     private final GoblintServer goblintServer;
     private final GoblintClient goblintClient;
+    private final GobPieConfiguration gobpieConfiguration;
     private final FileAlterationObserver goblintConfObserver;
 
     private final Logger log = LogManager.getLogger(GoblintAnalysis.class);
 
 
-    public GoblintAnalysis(MagpieServer magpieServer, GoblintServer goblintServer, GoblintClient goblintClient) {
+    public GoblintAnalysis(MagpieServer magpieServer, GoblintServer goblintServer, GoblintClient goblintClient, GobPieConfiguration gobpieConfiguration) {
         this.magpieServer = magpieServer;
         this.goblintServer = goblintServer;
         this.goblintClient = goblintClient;
+        this.gobpieConfiguration = gobpieConfiguration;
         this.goblintConfObserver = createGoblintConfObserver();
     }
 
@@ -97,7 +96,7 @@ public class GoblintAnalysis implements ServerAnalysis {
      */
 
     private void preAnalyse() {
-        String[] preAnalyzeCommand = goblintServer.getPreAnalyzeCommand();
+        String[] preAnalyzeCommand = gobpieConfiguration.getPreAnalyzeCommand();
         if (preAnalyzeCommand != null) {
             try {
                 log.info("Preanalyze command ran: \"" + Arrays.toString(preAnalyzeCommand) + "\"");
@@ -211,7 +210,7 @@ public class GoblintAnalysis implements ServerAnalysis {
         FileFilter fileFilter = new FileFilter() {
             @Override
             public boolean accept(File file) {
-                if (file.getName().equals(goblintServer.getGoblintConf())) return true;
+                if (file.getName().equals(gobpieConfiguration.getGoblintConf())) return true;
                 return false;
             };
         };

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -229,7 +229,7 @@ public class GoblintAnalysis implements ServerAnalysis {
         } catch (Exception e) {
             this.magpieServer.forwardMessageToClient(
                 new MessageParams(MessageType.Warning, "After changing the files list in Goblint configuration the server will not be automatically restarted. Close and reopen the IDE to restart the server manually if needed."));
-                log.error("Initializing goblintConfObserver failed: " + e.getMessage());
+            log.error("Initializing goblintConfObserver failed: " + e.getMessage());
         }
         return observer;
     }

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -224,8 +224,12 @@ public class GoblintAnalysis implements ServerAnalysis {
                     goblintServer.restartGoblintServer();
                     goblintClient.connectGoblintClient();
                 } catch (GobPieException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
+                    String message = "Unable to restart GobPie extension: " + e.getMessage();
+                        magpieServer.forwardMessageToClient( 
+                            new MessageParams(MessageType.Error, message + " Please check the output terminal of GobPie extension for more information.")
+                        );
+                    if (e.getCause() == null) log.error(message);
+                    else log.error(message + " Cause: " + e.getCause().getMessage());
                 }
             }
         });

--- a/src/main/java/analysis/GoblintAnalysisResult.java
+++ b/src/main/java/analysis/GoblintAnalysisResult.java
@@ -11,6 +11,15 @@ import magpiebridge.core.Kind;
 
 import org.eclipse.lsp4j.DiagnosticSeverity;
 
+/**
+ * The Class GoblintAnalysisResult.
+ * 
+ * Implementation of the MagpieBridge AnalysisResult class. 
+ * Customizes it for the needs of Goblint.
+ *
+ * @author Julian Dolby and Linghui Luo
+ */
+
 public class GoblintAnalysisResult implements AnalysisResult {
 
     private String group_text = "";

--- a/src/main/java/analysis/GoblintMessages.java
+++ b/src/main/java/analysis/GoblintMessages.java
@@ -9,6 +9,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * The Class GoblintMessages.
+ * 
+ * Corresponding object to the Goblint results in JSON.
+ * Converts the results from JSON to AnalysisResult requested by MagpieBridge.
+ * 
+ * @author      Karoliine Holter
+ * @since       0.0.1
+ */
 
 public class GoblintMessages {
 

--- a/src/main/java/analysis/GoblintPosition.java
+++ b/src/main/java/analysis/GoblintPosition.java
@@ -6,6 +6,13 @@ import com.ibm.wala.classLoader.IMethod;
 import java.io.Reader;
 import java.net.URL;
 
+/**
+ * The Class GoblintPosition.
+ * 
+ * @author      Karoliine Holter
+ * @since       0.0.1
+ */
+
 public class GoblintPosition implements Position {
 
     private int columnStart;

--- a/src/main/java/analysis/TagInterfaceAdapter.java
+++ b/src/main/java/analysis/TagInterfaceAdapter.java
@@ -8,6 +8,16 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 
+/**
+ * The Class TagInterfaceAdapter.
+ * 
+ * Implements the JsonDeserializer to deserialize json to GoblintResult objects.
+ * In particular to differentiate between the Category and CWE classes.
+ * 
+ * @author      Karoliine Holter
+ * @since       0.0.1
+ */
+
 public class TagInterfaceAdapter implements JsonDeserializer<Object> {
 
     @Override

--- a/src/main/java/goblintserver/GobPieConfiguration.java
+++ b/src/main/java/goblintserver/GobPieConfiguration.java
@@ -11,7 +11,7 @@ package goblintserver;
 
 public class GobPieConfiguration {
 
-    private String   goblintConf = "";
+    private String   goblintConf;
     private String[] preAnalyzeCommand;
 
     public String getGoblintConf() {

--- a/src/main/java/goblintserver/GobPieConfiguration.java
+++ b/src/main/java/goblintserver/GobPieConfiguration.java
@@ -10,7 +10,7 @@ public class GobPieConfiguration {
     }
 
     public String[] getPreAnalyzeCommand() {
-        if (preAnalyzeCommand.length < 0) return null;
+        if (preAnalyzeCommand == null || preAnalyzeCommand.length == 0) return null;
         return this.preAnalyzeCommand;
     }
 

--- a/src/main/java/goblintserver/GobPieConfiguration.java
+++ b/src/main/java/goblintserver/GobPieConfiguration.java
@@ -1,5 +1,14 @@
 package goblintserver;
 
+/**
+ * The Class GobPieConfiguration.
+ * 
+ * Corresponding object to the GobPie configuration JSON.
+ * 
+ * @author      Karoliine Holter
+ * @since       0.0.2
+ */
+
 public class GobPieConfiguration {
 
     private String   goblintConf = "";

--- a/src/main/java/goblintserver/GobPieException.java
+++ b/src/main/java/goblintserver/GobPieException.java
@@ -1,0 +1,28 @@
+package goblintserver;
+
+/**
+ * The Class GobPieException.
+ * 
+ * @author      Karoliine Holter
+ * @since       0.0.2
+ */
+
+public class GobPieException extends Exception {
+
+    private final GobPieExceptionType type;
+
+    public GobPieException(String message, Throwable cause, GobPieExceptionType type) {
+        super(message, cause);
+		this.type = type;
+	}
+
+    public GobPieException(String message, GobPieExceptionType type) {
+        super(message);
+		this.type = type;
+	}
+
+    public GobPieExceptionType getType() {
+        return type;
+    }
+    
+}

--- a/src/main/java/goblintserver/GobPieException.java
+++ b/src/main/java/goblintserver/GobPieException.java
@@ -7,7 +7,7 @@ package goblintserver;
  * @since       0.0.2
  */
 
-public class GobPieException extends Exception {
+public class GobPieException extends RuntimeException {
 
     private final GobPieExceptionType type;
 

--- a/src/main/java/goblintserver/GobPieExceptionType.java
+++ b/src/main/java/goblintserver/GobPieExceptionType.java
@@ -1,0 +1,7 @@
+package goblintserver;
+
+public enum GobPieExceptionType {
+    GOBLINT_EXCEPTION,
+    GOBPIE_EXCEPTION,
+    GOBPIE_CONF_EXCEPTION
+}

--- a/src/main/java/goblintserver/GoblintClient.java
+++ b/src/main/java/goblintserver/GoblintClient.java
@@ -48,7 +48,7 @@ public class GoblintClient {
      * @throws GobPieException in case Goblint socket is missing or the client was unable to connect to the socket.
      */
 
-    public void connectGoblintClient() throws GobPieException {
+    public void connectGoblintClient() {
         try {
             // connect to the goblint socket
             address = UnixDomainSocketAddress.of(Path.of(goblintSocketName));

--- a/src/main/java/goblintserver/GoblintClient.java
+++ b/src/main/java/goblintserver/GoblintClient.java
@@ -18,6 +18,14 @@ import com.google.gson.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+/**
+ * The Class GoblintClient.
+ * 
+ * Handles the communication with Goblint Server through unix socket.
+ * 
+ * @author      Karoliine Holter
+ * @since       0.0.2
+ */
 
 public class GoblintClient {
 
@@ -37,7 +45,6 @@ public class GoblintClient {
     /**
      * Method for connecting to Goblint server socket.
      *
-     * @return true if connection was started successfully, false otherwise.
      * @throws GobPieException in case Goblint socket is missing or the client was unable to connect to the socket.
      */
 
@@ -70,6 +77,7 @@ public class GoblintClient {
 
     /**
      * Method for reading the response from Goblint server.
+     * @return JsonObject of the results read from Goblint socket.
      */
 
     public JsonObject readResponseFromSocket() throws IOException {

--- a/src/main/java/goblintserver/GoblintClient.java
+++ b/src/main/java/goblintserver/GoblintClient.java
@@ -17,15 +17,10 @@ import com.google.gson.JsonObject;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.eclipse.lsp4j.MessageParams;
-import org.eclipse.lsp4j.MessageType;
-
-import magpiebridge.core.MagpieServer;
 
 
 public class GoblintClient {
 
-    private MagpieServer magpieServer;
     private SocketChannel channel;
     private UnixDomainSocketAddress address;
     private OutputStream outputStream;
@@ -36,18 +31,17 @@ public class GoblintClient {
     private final Logger log = LogManager.getLogger(GoblintClient.class);
 
 
-    public GoblintClient(MagpieServer magpieServer) {
-        this.magpieServer = magpieServer;
-    }
+    public GoblintClient() {}
 
 
     /**
      * Method for connecting to Goblint server socket.
      *
-     * @return True if connection was started successfully, false otherwise.
+     * @return true if connection was started successfully, false otherwise.
+     * @throws GobPieException in case Goblint socket is missing or the client was unable to connect to the socket.
      */
 
-    public boolean connectGoblintClient() {
+    public void connectGoblintClient() throws GobPieException {
         try {
             // connect to the goblint socket
             address = UnixDomainSocketAddress.of(Path.of(goblintSocketName));
@@ -56,12 +50,10 @@ public class GoblintClient {
             outputStream = Channels.newOutputStream(channel);
             InputStream inputStream = Channels.newInputStream(channel);
             inputReader = new BufferedReader(new InputStreamReader(inputStream));
-            if (!connected) return false;
+            if (!connected) throw new GobPieException("Connecting Goblint Client to Goblint socket failed.", GobPieExceptionType.GOBPIE_EXCEPTION);
             log.info("Goblint client connected.");
-            return true;
         } catch (IOException e) {
-            this.magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Connecting GoblintClient failed. " + e.getMessage()));
-            return false;
+            throw new GobPieException("Connecting Goblint Client  to Goblint socket failed.", e, GobPieExceptionType.GOBPIE_EXCEPTION);
         }
     }
 

--- a/src/main/java/goblintserver/GoblintServer.java
+++ b/src/main/java/goblintserver/GoblintServer.java
@@ -15,6 +15,15 @@ import org.zeroturnaround.exec.listener.ProcessListener;
 
 import static goblintserver.GobPieExceptionType.*;
 
+/**
+ * The Class GoblintServer.
+ * 
+ * Reads the configuration for GobPie extension, including Goblint's configuration file name.
+ * Starts Goblint Server and waits for the unix socket to be created.
+ * 
+ * @author      Karoliine Holter
+ * @since       0.0.2
+ */
 
 public class GoblintServer {
 
@@ -52,8 +61,7 @@ public class GoblintServer {
     /**
      * Method to start the Goblint server.
      *
-     * @return True if server was started successfully, false otherwise.
-     * @throws GobPieException
+     * @throws GobPieException thrown when running Goblint failed
      */
 
     public void startGoblintServer() throws GobPieException {
@@ -99,8 +107,7 @@ public class GoblintServer {
     /**
      * Method to restart the Goblint server.
      *
-     * @return True if new server was started successfully, false otherwise.
-     * @throws GobPieException
+     * @throws GobPieException thrown if starting Goblint Server throws an exception
      */
 
     public void restartGoblintServer() throws GobPieException {
@@ -147,11 +154,10 @@ public class GoblintServer {
      * Method for reading GobPie configuration.
      * Deserializes json to GobPieConfiguration object.
      *
-     * @return true if gobpie configuration was read sucessfully, false otherwise:
-     *      * no goblint configuration file was specified;
-     *      * no files to analyse have been listed;
-     *      * no gobpie.json file is found in root directory
-     * @throws GobPieException is thrown if gobpie conf cannot be found or the configuration parameters are missing.
+     * @throws GobPieException is thrown if
+     *      * configuration parameters are missing (no goblint configuration file was specified);
+     *      * gobpie conf cannot be found (no gobpie.json file is found in root directory)
+     *      * gobpie conf's json syntax is wrong
      */
 
     private void readGobPieConfiguration() throws GobPieException {

--- a/src/main/java/goblintserver/GoblintServer.java
+++ b/src/main/java/goblintserver/GoblintServer.java
@@ -22,8 +22,8 @@ public class GoblintServer {
 
     private MagpieServer magpieServer;
 
-    private String gobPieConf = "gobpie.json";
-    private String goblintSocket = "goblint.sock";
+    private final String gobPieConf;
+    private final String goblintSocket = "goblint.sock";
     private String goblintConf;
 
     private String[] preAnalyzeCommand;
@@ -34,8 +34,13 @@ public class GoblintServer {
     private final Logger log = LogManager.getLogger(GoblintClient.class);
 
 
-    public GoblintServer(MagpieServer magpieServer) {
+    public GoblintServer(MagpieServer magpieServer, String gobPieConfFileName) {
         this.magpieServer = magpieServer;
+        this.gobPieConf = gobPieConfFileName;
+    }
+
+    public String getGobPieConf() {
+        return gobPieConf;
     }
 
 
@@ -91,7 +96,7 @@ public class GoblintServer {
             return false;
             
         } catch (IOException | InvalidExitValueException | InterruptedException | TimeoutException e) {
-            this.magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Running Goblint failed. " + e.getMessage()));
+            log.error("Running Goblint failed. " + e.getMessage());
             return false;
         }
     }
@@ -136,8 +141,8 @@ public class GoblintServer {
                 } else if (process.exitValue() == 143) {
                     log.info("Goblint server has been killed.");
                 } else {
-                    magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Goblint server exited due to an error."));
-                    log.error("Goblint server exited due to an error.");
+                    magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Goblint server exited due to an error. Please check the output terminal of GobPie extension for more information."));
+                    log.error("Goblint server exited due to an error. Please fix the issue reported above and restart the extension.");
                 }
             }
         };
@@ -179,8 +184,7 @@ public class GoblintServer {
 
             // Check if all required parameters have been set
             if (goblintConf.equals("")) {
-                log.debug("Configuration parameters missing from GobPie configuration file");
-                this.magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Configuration parameters missing from GobPie configuration file."));
+                log.error("Configuration parameters missing from GobPie configuration file.");
                 return false;
             }
 
@@ -196,7 +200,7 @@ public class GoblintServer {
 
             log.debug("GobPie configuration read from json");
         } catch (FileNotFoundException e) {
-            this.magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Could not locate GobPie configuration file. " + e.getMessage()));
+            log.error("Could not locate GobPie configuration file. " + e.getMessage());
             return false;
         }
         return true;

--- a/src/main/java/goblintserver/Request.java
+++ b/src/main/java/goblintserver/Request.java
@@ -1,5 +1,14 @@
 package goblintserver;
 
+/**
+ * The Class Request.
+ * 
+ * Corresponding object to the jsonrpc request JSON.
+ * 
+ * @author      Karoliine Holter
+ * @since       0.0.2
+ */
+
 public class Request {
     // // {"jsonrpc":"2.0","id":0,"method":"analyze","params":{}}
 


### PR DESCRIPTION
As pointed out by @vesalvojdani in #26, the extension just crashes 5 times when the GobPie configuration is missing from the project root.

In this pull request
* The preAnalyzeCommand is made fully optional (can be missing from the configuration file)
* If GobPie conf is missing from the project root, the MagPieBridge server is still launched, but without being able to do any analyses. This way the extension does not crash. It is made so that it waits and checks until the conf file is created and then restarts the server automatically.
* Error messages are more meaningful and try to be more helpful. In particular, as the MagPieBridge server is running in any case, it is possible to send messages to the user using the popup to check for the messages in the terminal, where there are either Goblint or GobPie (more meaningful) error messages present.
* Changed the `info` type logs that are supposed to be `error` logs to the appropriate type.