### PR TITLE
Handle columns with negative values

### DIFF
--- a/src/main/java/analysis/GoblintMessages.java
+++ b/src/main/java/analysis/GoblintMessages.java
@@ -117,7 +117,7 @@ public class GoblintMessages {
 
     public GoblintAnalysisResult createGoblintAnalysisResult() throws MalformedURLException {
         int column = multipiece.loc.column < 0 ? 1 : multipiece.loc.column - 1;
-        int endColumn = multipiece.loc.endColumn< 0 ? 10000 : multipiece.loc.endColumn - 1;
+        int endColumn = multipiece.loc.endColumn < 0 ? 10000 : multipiece.loc.endColumn - 1;
         GoblintPosition pos = multipiece.loc == null 
                               ? new GoblintPosition(1, 1, 1, new File("").toURI().toURL()) 
                               : new GoblintPosition(multipiece.loc.line, multipiece.loc.endLine, column, endColumn, new File(multipiece.loc.file).toURI().toURL());
@@ -128,7 +128,7 @@ public class GoblintMessages {
 
     public GoblintAnalysisResult createGoblintAnalysisResult(multipiece.pieces piece) throws MalformedURLException {
         int column = piece.loc.column < 0 ? 1 : piece.loc.column - 1;
-        int endColumn = piece.loc.endColumn< 0 ? 10000 : piece.loc.endColumn - 1;
+        int endColumn = piece.loc.endColumn < 0 ? 10000 : piece.loc.endColumn - 1;
         GoblintPosition pos = piece.loc == null
                               ? new GoblintPosition(1, 1, 1, new File("").toURI().toURL())
                               : new GoblintPosition(piece.loc.line, piece.loc.endLine, column, endColumn, new File(piece.loc.file).toURI().toURL());

--- a/src/main/java/analysis/GoblintMessages.java
+++ b/src/main/java/analysis/GoblintMessages.java
@@ -116,18 +116,22 @@ public class GoblintMessages {
 
 
     public GoblintAnalysisResult createGoblintAnalysisResult() throws MalformedURLException {
+        int column = multipiece.loc.column < 0 ? 1 : multipiece.loc.column - 1;
+        int endColumn = multipiece.loc.endColumn< 0 ? 10000 : multipiece.loc.endColumn - 1;
         GoblintPosition pos = multipiece.loc == null 
                               ? new GoblintPosition(1, 1, 1, new File("").toURI().toURL()) 
-                              : new GoblintPosition(multipiece.loc.line, multipiece.loc.endLine, multipiece.loc.column - 1, multipiece.loc.endColumn - 1, new File(multipiece.loc.file).toURI().toURL());
+                              : new GoblintPosition(multipiece.loc.line, multipiece.loc.endLine, column, endColumn, new File(multipiece.loc.file).toURI().toURL());
         String msg = tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " " + multipiece.text;
         return new GoblintAnalysisResult(pos, msg, severity);
     }
 
 
     public GoblintAnalysisResult createGoblintAnalysisResult(multipiece.pieces piece) throws MalformedURLException {
+        int column = piece.loc.column < 0 ? 1 : piece.loc.column - 1;
+        int endColumn = piece.loc.endColumn< 0 ? 10000 : piece.loc.endColumn - 1;
         GoblintPosition pos = piece.loc == null
                               ? new GoblintPosition(1, 1, 1, new File("").toURI().toURL())
-                              : new GoblintPosition(piece.loc.line, piece.loc.endLine, piece.loc.column - 1, piece.loc.endColumn - 1, new File(piece.loc.file).toURI().toURL());
+                              : new GoblintPosition(piece.loc.line, piece.loc.endLine, column, endColumn, new File(piece.loc.file).toURI().toURL());
         return new GoblintAnalysisResult(pos,
                     tags.stream().map(tag -> tag.toString()).collect(Collectors.joining("")) + " Group: " + multipiece.group_text,
                     piece.text, severity);

--- a/src/main/java/analysis/GoblintMessages.java
+++ b/src/main/java/analysis/GoblintMessages.java
@@ -116,7 +116,7 @@ public class GoblintMessages {
 
 
     public GoblintAnalysisResult createGoblintAnalysisResult() throws MalformedURLException {
-        int column = multipiece.loc.column < 0 ? 1 : multipiece.loc.column - 1;
+        int column = multipiece.loc.column < 0 ? 0 : multipiece.loc.column - 1;
         int endColumn = multipiece.loc.endColumn < 0 ? 10000 : multipiece.loc.endColumn - 1;
         GoblintPosition pos = multipiece.loc == null 
                               ? new GoblintPosition(1, 1, 1, new File("").toURI().toURL()) 
@@ -127,7 +127,7 @@ public class GoblintMessages {
 
 
     public GoblintAnalysisResult createGoblintAnalysisResult(multipiece.pieces piece) throws MalformedURLException {
-        int column = piece.loc.column < 0 ? 1 : piece.loc.column - 1;
+        int column = piece.loc.column < 0 ? 0 : piece.loc.column - 1;
         int endColumn = piece.loc.endColumn < 0 ? 10000 : piece.loc.endColumn - 1;
         GoblintPosition pos = piece.loc == null
                               ? new GoblintPosition(1, 1, 1, new File("").toURI().toURL())


### PR DESCRIPTION
Goblint gives `-1` as the value of the start and end columns for some warnings. GobPie now handles this case by assigning `1` as the starting column and `10 000` as the end column value (assuming there are no lines longer than 10 000 characters). With this, showing warnings in the [Chrony](https://github.com/goblint/bench/issues/17) project is now working. 
