### PR TITLE
Use analysis abort in server mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,13 @@
             <version>1.12</version>
         </dependency>
 
+        <!-- zt-process-killer -->
+        <dependency>
+            <groupId>org.zeroturnaround</groupId>
+            <artifactId>zt-process-killer</artifactId>
+            <version>1.10</version>
+        </dependency>
+
         <!-- log4j -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 
 public class GoblintAnalysis implements ServerAnalysis {
@@ -44,7 +45,7 @@ public class GoblintAnalysis implements ServerAnalysis {
     private final FileAlterationObserver goblintConfObserver;
     private final int SIGINT = 2;
 
-    private Boolean analysisRunning = false;
+    private boolean analysisRunning = false;
 
     private final Logger log = LogManager.getLogger(GoblintAnalysis.class);
 
@@ -88,13 +89,13 @@ public class GoblintAnalysis implements ServerAnalysis {
                 goblintConfObserver.checkAndNotify();
                 preAnalyse();
 
-                log.info("\n---------------------- Analysis started ----------------------");
+                log.info("---------------------- Analysis started ----------------------");
                 analysisRunning = true;
                 Collection<GoblintAnalysisResult> response = reanalyse();
                 if (response != null) {
                     server.consume(new ArrayList<>(response), source());
                     analysisRunning = false;
-                    log.info("--------------------- Analysis finished ----------------------\n");
+                    log.info("--------------------- Analysis finished ----------------------");
                 }
             }
         }
@@ -129,7 +130,7 @@ public class GoblintAnalysis implements ServerAnalysis {
         UnixProcess unixProcess = new UnixProcess(pid);
         try {
             unixProcess.kill(SIGINT);
-            log.info("--------------- This analysis has been aborted -------------\n");
+            log.info("--------------- This analysis has been aborted -------------");
         } catch (IOException e) {
             log.error("Aborting analysis failed.");
         }

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -90,7 +90,7 @@ public class GoblintAnalysis implements ServerAnalysis {
                 System.err.println("\n---------------------- Analysis started ----------------------");
                 analysisRunning = true;
                 Collection<GoblintAnalysisResult> response = reanalyse();
-                if (response != null) server.consume(new ArrayList<>(response), source());
+                server.consume(new ArrayList<>(response), source());
                 analysisRunning = false;
                 System.err.println("--------------------- Analysis finished ----------------------\n");
 
@@ -156,8 +156,7 @@ public class GoblintAnalysis implements ServerAnalysis {
                 throw new GobPieException("Response ID does not match request ID.", GobPieExceptionType.GOBLINT_EXCEPTION);
             return convertResultsFromJson(messagesResponse);
         } catch (IOException e) {
-            log.info("Sending the request to or receiving result from the server failed: " + e);
-            return null;
+            throw new GobPieException("Sending the request to or receiving result from the server failed.", e, GobPieExceptionType.GOBLINT_EXCEPTION);
         }
     }
 

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -132,10 +132,7 @@ public class GoblintAnalysis implements ServerAnalysis {
             UnixProcess unixProcess = new UnixProcess(pid);
             try {
                 unixProcess.kill(SIGINT);
-                lastAnalysisTask.cancel(false);
-                if (lastAnalysisTask.isCancelled()) {
-                    log.info("--------------- This analysis has been aborted -------------");
-                }
+                log.info("--------------- This analysis has been aborted -------------");
             } catch (IOException e) {
                 log.error("Aborting analysis failed.");
             }

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -90,10 +90,11 @@ public class GoblintAnalysis implements ServerAnalysis {
                 System.err.println("\n---------------------- Analysis started ----------------------");
                 analysisRunning = true;
                 Collection<GoblintAnalysisResult> response = reanalyse();
-                server.consume(new ArrayList<>(response), source());
-                analysisRunning = false;
-                System.err.println("--------------------- Analysis finished ----------------------\n");
-
+                if (response != null) {
+                    server.consume(new ArrayList<>(response), source());
+                    analysisRunning = false;
+                    System.err.println("--------------------- Analysis finished ----------------------\n");
+                }
             }
         }
     }
@@ -127,7 +128,7 @@ public class GoblintAnalysis implements ServerAnalysis {
         UnixProcess unixProcess = new UnixProcess(pid);
         try {
             unixProcess.kill(2);
-            System.err.println("\n-------------- This analysis has been aborted ------------");
+            System.err.println("--------------- This analysis has been aborted -------------\n");
         } catch (IOException e) {
             log.error("Aborting analysis failed.");
         }
@@ -150,6 +151,8 @@ public class GoblintAnalysis implements ServerAnalysis {
             AnalyzeResponse analyzeResponse = goblintClient.readAnalyzeResponseFromSocket();
             if (!analyzeRequest.getId().equals(analyzeResponse.getId()))
                 throw new GobPieException("Response ID does not match request ID.", GobPieExceptionType.GOBLINT_EXCEPTION);
+            if (analyzeResponse.getResult().getStatus().contains("Aborted"))
+                return null;
             goblintClient.writeRequestToSocket(messagesRequest);
             MessagesResponse messagesResponse = goblintClient.readMessagesResponseFromSocket();
             if (!messagesRequest.getId().equals(messagesResponse.getId()))

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -42,6 +42,7 @@ public class GoblintAnalysis implements ServerAnalysis {
     private final GoblintClient goblintClient;
     private final GobPieConfiguration gobpieConfiguration;
     private final FileAlterationObserver goblintConfObserver;
+    private final int SIGINT = 2;
 
     private Boolean analysisRunning = false;
 
@@ -127,7 +128,7 @@ public class GoblintAnalysis implements ServerAnalysis {
         int pid = Math.toIntExact(goblintProcess.pid());
         UnixProcess unixProcess = new UnixProcess(pid);
         try {
-            unixProcess.kill(2);
+            unixProcess.kill(SIGINT);
             System.err.println("--------------- This analysis has been aborted -------------\n");
         } catch (IOException e) {
             log.error("Aborting analysis failed.");

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -88,13 +88,13 @@ public class GoblintAnalysis implements ServerAnalysis {
                 goblintConfObserver.checkAndNotify();
                 preAnalyse();
 
-                System.err.println("\n---------------------- Analysis started ----------------------");
+                log.info("\n---------------------- Analysis started ----------------------");
                 analysisRunning = true;
                 Collection<GoblintAnalysisResult> response = reanalyse();
                 if (response != null) {
                     server.consume(new ArrayList<>(response), source());
                     analysisRunning = false;
-                    System.err.println("--------------------- Analysis finished ----------------------\n");
+                    log.info("--------------------- Analysis finished ----------------------\n");
                 }
             }
         }
@@ -129,7 +129,7 @@ public class GoblintAnalysis implements ServerAnalysis {
         UnixProcess unixProcess = new UnixProcess(pid);
         try {
             unixProcess.kill(SIGINT);
-            System.err.println("--------------- This analysis has been aborted -------------\n");
+            log.info("--------------- This analysis has been aborted -------------\n");
         } catch (IOException e) {
             log.error("Aborting analysis failed.");
         }

--- a/src/main/java/goblintclient/GoblintClient.java
+++ b/src/main/java/goblintclient/GoblintClient.java
@@ -80,7 +80,7 @@ public class GoblintClient {
     public void writeRequestToSocket(Request request) throws IOException {
         String requestString = new GsonBuilder().create().toJson(request) + "\n";
         outputStream.write(requestString.getBytes());
-        log.info("Request " + request.getId() + " written to socket.");
+        log.info("Request (" + request.getMethod() + ") " + request.getId() + " written to socket.");
     }
 
 
@@ -93,7 +93,7 @@ public class GoblintClient {
     public AnalyzeResponse readAnalyzeResponseFromSocket() throws IOException {
         String response = inputReader.readLine();
         AnalyzeResponse analyzeResponse = new Gson().fromJson(response, AnalyzeResponse.class);
-        log.info("Response " + analyzeResponse.getId() + " read from socket.");
+        log.info("Response (analyze) " + analyzeResponse.getId() + " read from socket.");
         return analyzeResponse;
     }
 
@@ -111,7 +111,7 @@ public class GoblintClient {
         builder.registerTypeAdapter(GoblintMessages.tag.class, new GoblintTagInterfaceAdapter());
         Gson gson = builder.create();
         MessagesResponse messagesResponse = gson.fromJson(response, MessagesResponse.class);
-        log.info("Response " + messagesResponse.getId() + " read from socket.");
+        log.info("Response (messages) " + messagesResponse.getId() + " read from socket.");
         return messagesResponse;
     }
 

--- a/src/main/java/goblintclient/communication/AnalyzeResponse.java
+++ b/src/main/java/goblintclient/communication/AnalyzeResponse.java
@@ -18,7 +18,7 @@ public class AnalyzeResponse extends Response {
 
     private result result;
 
-    static class result {
+    public static class result {
         private final List<String> status = new ArrayList<>();
 
         public List<String> getStatus() {

--- a/src/main/java/goblintserver/GoblintServer.java
+++ b/src/main/java/goblintserver/GoblintServer.java
@@ -148,7 +148,7 @@ public class GoblintServer {
                     log.info("Goblint server has been killed.");
                 } else {
                     magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Goblint server exited due to an error. Please check the output terminal of GobPie extension for more information."));
-                    log.error("Goblint server exited due to an error. Please fix the issue reported above and restart the extension.");
+                    log.error("Goblint server exited due to an error (code: " + process.exitValue() + "). Please fix the issue reported above and restart the extension.");
                 }
             }
         };

--- a/src/main/java/goblintserver/GoblintServer.java
+++ b/src/main/java/goblintserver/GoblintServer.java
@@ -51,6 +51,10 @@ public class GoblintServer {
         return goblintConf;
     }
 
+    public StartedProcess getGoblintRunProcess() {
+        return goblintRunProcess;
+    }
+
 
     /**
      * Method for constructing the command to run Goblint server.

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -1,23 +1,20 @@
 'use strict';
-import * as net from 'net';
-import * as path from 'path';
-
-import {  workspace, window, ExtensionContext } from 'vscode';
-import { LanguageClient, LanguageClientOptions, ServerOptions, StreamInfo } from 'vscode-languageclient';
+import {ExtensionContext, workspace} from 'vscode';
+import {LanguageClient, LanguageClientOptions, ServerOptions} from 'vscode-languageclient';
 
 export function activate(context: ExtensionContext) {
     let script = 'java';
-    let args = ['-jar',context.asAbsolutePath('gobpie-0.0.2-SNAPSHOT.jar')];
-    
-    // Use this for communicating on stdio 
+    let args = ['-jar', context.asAbsolutePath('gobpie-0.0.2-SNAPSHOT.jar')];
+
+    // Use this for communicating on stdio
     let serverOptions: ServerOptions = {
-        run : { command: script, args: args },
-        debug: { command: script, args: args} ,
+        run: {command: script, args: args},
+        debug: {command: script, args: args},
     };
-    
-   /**
-    *   Use this for debugging 
-    *   let serverOptions = () => {
+
+    /**
+     *   Use this for debugging
+     *   let serverOptions = () => {
 		const socket = net.connect({ port: 5007 })
 		const result: StreamInfo = {
 			writer: socket,
@@ -27,21 +24,21 @@ export function activate(context: ExtensionContext) {
 			socket.on("connect", () => resolve(result))
 			socket.on("error", _ =>
 				window.showErrorMessage(
-					"Failed to connect to TaintBench language server. Make sure that the language server is running " +
+					"Failed to connect to the language server. Make sure that the language server is running " +
 					"-or- configure the extension to connect via standard IO."))
 		})
     }*/
-    
+
     let clientOptions: LanguageClientOptions = {
-        documentSelector: [{ scheme: 'file', language: 'c' }],
+        documentSelector: [{scheme: 'file', language: 'c'}],
         synchronize: {
             configurationSection: 'c',
-            fileEvents: [ workspace.createFileSystemWatcher('**/*.c') ]
+            fileEvents: [workspace.createFileSystemWatcher('**/*.c')]
         }
     };
-    
+
     // Create the language client and start the client.
-    let lc : LanguageClient = new LanguageClient('GobPie','GobPie', serverOptions, clientOptions);
+    let lc: LanguageClient = new LanguageClient('GobPie', 'GobPie', serverOptions, clientOptions);
     lc.start();
 }
 


### PR DESCRIPTION
This branch has the initial abort logic, relating to #20. Although the initial version works for aborting the analysis and starting a new one, it executes the code in GobPie following the reanalysis even after the abort. This results in the actions (reading the results from the socket and printing "analysis finished") being executed consecutively as many times as the analysis was restarted.

To solve this issue, we have discussed with @sim642 to try and use Java threads for the actions from triggering analyses to requesting results.