### PR TITLE
Reload Goblint configuration in existing server instead of restarting 

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,5 +1,7 @@
 import analysis.GoblintAnalysis;
 import analysis.ShowCFGCommand;
+import api.GoblintService;
+import api.messages.Params;
 import com.google.gson.*;
 import api.GoblintClient;
 import api.GoblintServiceLauncher;
@@ -100,15 +102,19 @@ public class Main {
         GoblintServiceLauncher.Builder builder = new GoblintServiceLauncher.Builder();
         GoblintServiceLauncher goblintServiceLauncher = builder.create(localEndpoint);
         goblintServiceLauncher.startListening();
+        GoblintService goblintService = localEndpoint.getServer();
+
+        // read Goblint configurations
+        goblintService.read_config(new Params(new File(goblintServer.getGoblintConf()).getAbsolutePath()));
 
         // add analysis to the MagpieServer
-        ServerAnalysis serverAnalysis = new GoblintAnalysis(magpieServer, goblintServer, localEndpoint.getServer(), gobpieConfiguration);
+        ServerAnalysis serverAnalysis = new GoblintAnalysis(magpieServer, goblintServer, goblintService, gobpieConfiguration);
         Either<ServerAnalysis, ToolAnalysis> analysis = Either.forLeft(serverAnalysis);
         magpieServer.addAnalysis(analysis, language);
 
         // add HTTP server for showing CFGs
         magpieServer.addHttpServer(cfgHttpServer);
-        magpieServer.addCommand("showcfg", new ShowCFGCommand(localEndpoint.getServer()));
+        magpieServer.addCommand("showcfg", new ShowCFGCommand(goblintService));
     }
 
 

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -233,8 +233,8 @@ public class GoblintAnalysis implements ServerAnalysis {
         observer.addListener(new FileAlterationListenerAdaptor() {
             @Override
             public void onFileChange(File file) {
-                Params params = new Params(new File(goblintServer.getGoblintConf()).getAbsolutePath());
-                goblintService.read_config(params);
+                goblintService.reset_config();
+                goblintService.read_config(new Params(new File(goblintServer.getGoblintConf()).getAbsolutePath()));
             }
         });
 

--- a/src/main/java/api/GoblintService.java
+++ b/src/main/java/api/GoblintService.java
@@ -50,6 +50,9 @@ public interface GoblintService {
     CompletableFuture<GoblintCFGResult> cfg(Params params);
 
     @JsonRequest
+    CompletableFuture<Void> reset_config();
+
+    @JsonRequest
     CompletableFuture<Void> read_config(Params params);
 
 }

--- a/src/main/java/goblintserver/GoblintServer.java
+++ b/src/main/java/goblintserver/GoblintServer.java
@@ -66,7 +66,7 @@ public class GoblintServer {
 
     private String[] constructGoblintRunCommand() {
         return Arrays.stream(new String[]{
-                        "goblint", "--conf", new File(goblintConf).getAbsolutePath(),
+                        "goblint",
                         "--enable", "server.enabled",
                         "--enable", "server.reparse",
                         "--set", "server.mode", "unix",
@@ -84,16 +84,17 @@ public class GoblintServer {
     public void startGoblintServer() {
 
         try {
+            WatchService watchService = FileSystems.getDefault().newWatchService();
+            Path path = Paths.get(System.getProperty("user.dir"));
+            path.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
+            WatchKey key;
+
             // run command to start goblint
             log.info("Goblint run with command: " + String.join(" ", goblintRunCommand));
 
             goblintRunProcess = runCommand(new File(System.getProperty("user.dir")), goblintRunCommand);
 
             // wait until Goblint socket is created before continuing
-            WatchService watchService = FileSystems.getDefault().newWatchService();
-            Path path = Paths.get(System.getProperty("user.dir"));
-            path.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
-            WatchKey key;
             while ((key = watchService.take()) != null) {
                 for (WatchEvent<?> event : key.pollEvents()) {
                     if ((event.context()).equals(Paths.get(goblintSocket))) {


### PR DESCRIPTION
Use `reset_config` and `read_config` requests to reload new Goblint configuration. The configuration is always reset to the configuration that was initially given from the command line. GobPie now starts Goblint without giving a configuration file on the command line when starting the server, to be able to still parse the initial command even in case the (first) configuration file gets deleted. The configuration is now only read via `read_config` request.

Can be merged after goblint/analyzer#817.

Solves #32.