### PR TITLE
Showing CFG node states

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,12 +28,14 @@ Example configuration file `gobpie.json`:
 ```
 {
     "goblintConf" : "goblint.json",
-    "preAnalyzeCommand" : ["cmake", "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON", "-B", "build"]
+    "preAnalyzeCommand" : ["cmake", "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON", "-B", "build"],
+    "showCfg": true
 }
 ```
 
 * `goblintConf` - the relative path from project root to the goblint configuration file (required)
 * `preAnalyzeCommand` - the command to run before analysing (e.g. command for building/updating the compilation database for some automation) (optional)
+* `showCfg` - if the code actions for showing function's CFGs are shown
 
 Goblint configuration file (e.g. `goblint.json`) must have field `files` defined:
 
@@ -63,6 +65,6 @@ vsce package
 
 ## To test the extension
 
-1. Clone the [demoproject](https://github.com/karoliineh/GoblintAnalyzer-DemoProject)
+1. Clone the [demo project](https://github.com/karoliineh/GoblintAnalyzer-DemoProject)
 2. In the repository's folder, activate the right opam switch.
 3. Open the project in VSCode.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <dependency>
             <groupId>org.eclipse.lsp4j</groupId>
             <artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
-            <version>0.14.0</version>
+            <version>0.15.0</version>
         </dependency>
 
 
@@ -69,12 +69,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.15.0</version>
+            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.15.0</version>
+            <version>2.19.0</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,14 @@
             <version>1.10</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.thymeleaf/thymeleaf -->
+        <dependency>
+            <groupId>org.thymeleaf</groupId>
+            <artifactId>thymeleaf</artifactId>
+            <version>3.0.15.RELEASE</version>
+        </dependency>
+
+
         <!-- log4j -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/src/main/java/HTTPserver/GobPieHTTPServer.java
+++ b/src/main/java/HTTPserver/GobPieHTTPServer.java
@@ -8,6 +8,15 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
+/**
+ * The Class GobPieHTTPServer.
+ * <p>
+ * The class creates a simple HTTP server.
+ *
+ * @author Karoliine Holter
+ * @since 0.0.3
+ */
+
 public class GobPieHTTPServer {
     private HttpServer httpServer;
 
@@ -18,9 +27,6 @@ public class GobPieHTTPServer {
         try {
             InetSocketAddress socket = new InetSocketAddress("0.0.0.0", 0);
             httpServer = HttpServer.create(socket, 42);
-            /*System.out.println(Arrays.toString());
-            Inet4Address.getAllByName()*/
-
 
             httpServerAddress = "http://localhost:" + this.httpServer.getAddress().getPort() + "/";
             httpServer.createContext("/", new GobPieHttpHandler(httpServerAddress, goblintService));

--- a/src/main/java/HTTPserver/GobPieHTTPServer.java
+++ b/src/main/java/HTTPserver/GobPieHTTPServer.java
@@ -1,0 +1,42 @@
+package HTTPserver;
+
+import api.GoblintService;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+public class GobPieHTTPServer {
+    private HttpServer httpServer;
+
+    private String httpServerAddress;
+    private final Logger log = LogManager.getLogger(GobPieHTTPServer.class);
+
+    public GobPieHTTPServer(GoblintService goblintService) {
+        try {
+            InetSocketAddress socket = new InetSocketAddress("0.0.0.0", 0);
+            httpServer = HttpServer.create(socket, 42);
+            /*System.out.println(Arrays.toString());
+            Inet4Address.getAllByName()*/
+
+
+            httpServerAddress = "http://localhost:" + this.httpServer.getAddress().getPort() + "/";
+            httpServer.createContext("/", new GobPieHttpHandler(httpServerAddress, goblintService));
+            httpServer.createContext("/cfg/", new GobPieHttpHandler(httpServerAddress, goblintService));
+            httpServer.createContext("/node/", new GobPieHttpHandler(httpServerAddress, goblintService));
+
+            httpServer.setExecutor(null);
+        } catch (IOException e) {
+            log.error(e.getStackTrace());
+        }
+    }
+
+    public String start() {
+        httpServer.start();
+        log.info("HTTP server started on: " + httpServerAddress);
+        return httpServerAddress;
+    }
+
+}

--- a/src/main/java/HTTPserver/GobPieHttpHandler.java
+++ b/src/main/java/HTTPserver/GobPieHttpHandler.java
@@ -23,6 +23,16 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
+/**
+ * The Class GobPieHttpHandler.
+ * <p>
+ * Implements the class {@link HttpHandler}.
+ * Handles the requests sent to the HTTP server.
+ *
+ * @author Karoliine Holter
+ * @since 0.0.3
+ */
+
 public class GobPieHttpHandler implements HttpHandler {
 
     private static final int HTTP_OK_STATUS = 200;

--- a/src/main/java/HTTPserver/GobPieHttpHandler.java
+++ b/src/main/java/HTTPserver/GobPieHttpHandler.java
@@ -86,7 +86,17 @@ public class GobPieHttpHandler implements HttpHandler {
                 default -> templateEngine.process("index", context);
             };
         } else {
-            response = templateEngine.process("index", context);
+            response = switch (path) {
+                case "/static/jsonTree.css/" -> {
+                    templateEngine = createTemplateEngine("/json-viewer/", ".css", TemplateMode.CSS);
+                    yield templateEngine.process("jquery.json-viewer", context);
+                }
+                case "/static/jsonTree.js/" -> {
+                    templateEngine = createTemplateEngine("/json-viewer/", ".js", TemplateMode.JAVASCRIPT);
+                    yield templateEngine.process("jquery.json-viewer", context);
+                }
+                default -> templateEngine.process("index", context);
+            };
         }
         exchange.sendResponseHeaders(HTTP_OK_STATUS, response.getBytes().length);
         writeResponse(os, response);

--- a/src/main/java/HTTPserver/GobPieHttpHandler.java
+++ b/src/main/java/HTTPserver/GobPieHttpHandler.java
@@ -1,0 +1,175 @@
+package HTTPserver;
+
+import api.GoblintService;
+import api.messages.GoblintCFGResult;
+import api.messages.Params;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import gobpie.GobPieException;
+import gobpie.GobPieExceptionType;
+import guru.nidi.graphviz.engine.Format;
+import guru.nidi.graphviz.engine.Graphviz;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.templatemode.TemplateMode;
+import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+public class GobPieHttpHandler implements HttpHandler {
+
+    private static final int HTTP_OK_STATUS = 200;
+    private final String httpServerAddress;
+    private final GoblintService goblintService;
+
+    private final Logger log = LogManager.getLogger(GobPieHttpHandler.class);
+
+    public GobPieHttpHandler(String httpServerAddress, GoblintService goblintService) {
+        this.httpServerAddress = httpServerAddress;
+        this.goblintService = goblintService;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+
+        String path = exchange.getRequestURI().getPath();
+        OutputStream os = exchange.getResponseBody();
+        InputStream is = exchange.getRequestBody();
+        String response;
+
+        // CORS
+        exchange.getResponseHeaders().add("Access-Control-Allow-Origin", "*");
+        if (exchange.getRequestMethod().equalsIgnoreCase("OPTIONS")) {
+            exchange.getResponseHeaders().add("Access-Control-Allow-Methods", "GET, OPTIONS");
+            exchange.getResponseHeaders().add("Access-Control-Allow-Headers", "Content-Type,Authorization");
+            exchange.sendResponseHeaders(204, -1);
+            return;
+        }
+
+        TemplateEngine templateEngine = createTemplateEngine();
+        Context context = new Context();
+
+        switch (path) {
+            case "/":
+                response = templateEngine.process("index", context);
+                exchange.sendResponseHeaders(HTTP_OK_STATUS, response.getBytes().length);
+                writeResponse(os, response);
+                break;
+            case "/cfg/":
+                String funName = readRequestBody(is).get("funName").getAsString();
+                context.setVariable("cfgSvg", getCFG(funName));
+                context.setVariable("url", httpServerAddress + "node/");
+                log.info("Showing CFG for function: " + funName);
+
+                response = templateEngine.process("base", context);
+                exchange.sendResponseHeaders(HTTP_OK_STATUS, response.getBytes().length);
+                writeResponse(os, response);
+                break;
+            case "/node/":
+                List<JsonObject> states = getNodeStates(readRequestBody(is).get("node").getAsString());
+
+                response = states.get(0).toString();
+                exchange.sendResponseHeaders(HTTP_OK_STATUS, response.getBytes().length);
+                writeResponse(os, response);
+                break;
+        }
+
+    }
+
+    private JsonObject readRequestBody(InputStream is) {
+        return JsonParser.parseReader(new InputStreamReader(is, StandardCharsets.UTF_8)).getAsJsonObject();
+    }
+
+    private void writeResponse(OutputStream os, String response) throws IOException {
+        os.write(response.getBytes());
+        os.flush();
+        os.close();
+    }
+
+
+    /**
+     * Creates the Thymeleaf Template Engine
+     * for accessing the templates from resources/templates.
+     *
+     * @return TemplateEngine instance
+     */
+    private TemplateEngine createTemplateEngine() {
+        ClassLoaderTemplateResolver resolver = new ClassLoaderTemplateResolver();
+        resolver.setTemplateMode(TemplateMode.HTML);
+        resolver.setCharacterEncoding("UTF-8");
+        resolver.setPrefix("/templates/");
+        resolver.setSuffix(".html");
+
+        TemplateEngine templateEngine = new TemplateEngine();
+        templateEngine.setTemplateResolver(resolver);
+
+        return templateEngine;
+    }
+
+
+    /**
+     * Sends the request to get the CFG for the given function,
+     * converts the CFG to a svg and returns it.
+     *
+     * @param funName The function name for which the CFG was requested.
+     * @return The CFG of the given function as a svg.
+     * @throws GobPieException if the request and response ID do not match.
+     */
+    private String getCFG(String funName) {
+        Params params = new Params(funName);
+        try {
+            GoblintCFGResult cfgResponse = goblintService.cfg(params).get();
+            String cfg = cfgResponse.getCfg();
+            return cfg2svg(cfg);
+        } catch (ExecutionException | InterruptedException e) {
+            throw new GobPieException("Sending the request to or receiving result from the server failed.", e, GobPieExceptionType.GOBLINT_EXCEPTION);
+        }
+    }
+
+    /**
+     * Converts the dot language string to a svg.
+     *
+     * @param cfg The CFG as a dot language string.
+     * @return The CFG of the given function as a svg.
+     * @throws GobPieException TODO: description
+     */
+
+    private String cfg2svg(String cfg) {
+        try {
+            // Generate svg from dot using graphviz-java
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            Graphviz.fromString(cfg).render(Format.SVG).toOutputStream(output);
+            String svg = output.toString();
+            // TODO: figure out something else instead of the following replace ugliness
+            return svg.replaceAll("xlink:href=\"javascript:", "onclick=\"");
+        } catch (IOException e) {
+            // TODO: meaningful error message
+            throw new GobPieException("", e, GobPieExceptionType.GOBPIE_EXCEPTION);
+        }
+    }
+
+
+    /**
+     * Sends the request to get the state info for the given CFG node.
+     *
+     * @param nodeId The id of the node for which the states are requested.
+     * @return A list of json objects expressing the state.
+     * @throws GobPieException if the request and response ID do not match.
+     */
+    private List<JsonObject> getNodeStates(String nodeId) {
+        Params params = new Params(nodeId);
+        try {
+            return goblintService.node_state(params).get();
+        } catch (ExecutionException | InterruptedException e) {
+            throw new GobPieException("Sending the request to or receiving result from the server failed.", e, GobPieExceptionType.GOBLINT_EXCEPTION);
+        }
+    }
+
+}

--- a/src/main/java/HTTPserver/GobPieHttpHandler.java
+++ b/src/main/java/HTTPserver/GobPieHttpHandler.java
@@ -164,11 +164,23 @@ public class GobPieHttpHandler implements HttpHandler {
      * @throws GobPieException if the request and response ID do not match.
      */
     private List<JsonObject> getNodeStates(String nodeId) {
-        Params params = new Params(nodeId);
+        NodeParams params = new NodeParams(nodeId);
         try {
             return goblintService.node_state(params).get();
         } catch (ExecutionException | InterruptedException e) {
             throw new GobPieException("Sending the request to or receiving result from the server failed.", e, GobPieExceptionType.GOBLINT_EXCEPTION);
+        }
+    }
+
+    public static class NodeParams {
+
+        private String nid;
+
+        public NodeParams() {
+        }
+
+        public NodeParams(String nid) {
+            this.nid = nid;
         }
     }
 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -133,7 +133,7 @@ public class Main {
     private static GobPieConfiguration readGobPieConfiguration() {
 
         // If gobpie configuration is not present, wait for it to be created
-        if (!new File(System.getProperty("user.dir") + "/" + "gobpie.json").exists()) {
+        if (!new File(System.getProperty("user.dir") + "/" + gobPieConfFileName).exists()) {
             String message = "GobPie configuration file is not found in the project root.";
             String terminalMessage = message + "\nPlease add GobPie configuration file into the project root.";
             forwardErrorMessageToClient(message, terminalMessage);

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -3,13 +3,12 @@ import analysis.GoblintAnalysis;
 import analysis.ShowCFGCommand;
 import api.GoblintService;
 import api.messages.Params;
-import com.google.gson.*;
 import api.GoblintClient;
 import api.GoblintServiceLauncher;
 import goblintserver.GoblintServer;
+import gobpie.GobPieConfReader;
 import gobpie.GobPieConfiguration;
 import gobpie.GobPieException;
-import gobpie.GobPieExceptionType;
 import magpiebridge.core.MagpieServer;
 import magpiebridge.core.ServerAnalysis;
 import magpiebridge.core.ServerConfiguration;
@@ -21,10 +20,6 @@ import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.file.*;
 
 public class Main {
 
@@ -90,7 +85,8 @@ public class Main {
         String language = "c";
 
         // read gobpie configuration file
-        GobPieConfiguration gobpieConfiguration = readGobPieConfiguration();
+        GobPieConfReader gobPieConfReader = new GobPieConfReader(magpieServer, gobPieConfFileName);
+        GobPieConfiguration gobpieConfiguration = gobPieConfReader.readGobPieConfiguration();
 
         // start GoblintServer
         GoblintServer goblintServer = new GoblintServer(gobpieConfiguration.getGoblintConf(), magpieServer);
@@ -117,105 +113,6 @@ public class Main {
         String httpServerAddress = new GobPieHTTPServer(goblintService).start();
         magpieServer.addHttpServer(httpServerAddress);
         magpieServer.addCommand("showcfg", new ShowCFGCommand(httpServerAddress));
-    }
-
-
-    /**
-     * Method for reading GobPie configuration.
-     * <p>
-     * Waits for the Gobpie configuration file to be created if one is not present in the project root.
-     * Checks if all the required parameters are present in the configuration and
-     * if not, waits for the file to be changed and reparses it until the user gives the parameters.
-     *
-     * @return GobPieConfiguration object.
-     */
-
-    private static GobPieConfiguration readGobPieConfiguration() {
-
-        // If gobpie configuration is not present, wait for it to be created
-        if (!new File(System.getProperty("user.dir") + "/" + gobPieConfFileName).exists()) {
-            String message = "GobPie configuration file is not found in the project root.";
-            String terminalMessage = message + "\nPlease add GobPie configuration file into the project root.";
-            forwardErrorMessageToClient(message, terminalMessage);
-            waitForGobPieConf();
-        }
-
-        // Parse the configuration file
-        GobPieConfiguration gobpieConfiguration = parseGobPieConf();
-
-        // Check if all required parameters have been set
-        // If not, wait for change and reparse
-        String goblintConf = gobpieConfiguration.getGoblintConf();
-        while (goblintConf == null || goblintConf.equals("")) {
-            String message = "goblintConf parameter missing from GobPie configuration file.";
-            String terminalMessage = message + "\nPlease add Goblint configuration file location into GobPie configuration as a parameter with name \"goblintConf\".";
-            forwardErrorMessageToClient(message, terminalMessage);
-            waitForGobPieConf();
-            gobpieConfiguration = parseGobPieConf();
-            goblintConf = gobpieConfiguration.getGoblintConf();
-        }
-
-        return gobpieConfiguration;
-
-
-    }
-
-
-    /**
-     * Method for parsing GobPie configuration.
-     * Deserializes json to GobPieConfiguration object.
-     *
-     * @return GobPieConfiguration object.
-     * @throws GobPieException if
-     *                         <ul>
-     *                             <li>gobpie conf cannot be found to be read from;</li>
-     *                             <li>gobpie conf json syntax is wrong.</li>
-     *                         </ul>
-     */
-
-    private static GobPieConfiguration parseGobPieConf() {
-        try {
-            log.debug("Reading GobPie configuration from json");
-            Gson gson = new GsonBuilder().create();
-            // Read json object
-            JsonObject jsonObject = JsonParser.parseReader(new FileReader(gobPieConfFileName)).getAsJsonObject();
-            // Convert json object to GobPieConfiguration object
-            log.debug("GobPie configuration read from json");
-            return gson.fromJson(jsonObject, GobPieConfiguration.class);
-        } catch (FileNotFoundException e) {
-            throw new GobPieException("Could not locate GobPie configuration file.", e, GobPieExceptionType.GOBPIE_CONF_EXCEPTION);
-        } catch (JsonSyntaxException e) {
-            throw new GobPieException("GobPie configuration file syntax is wrong.", e, GobPieExceptionType.GOBPIE_CONF_EXCEPTION);
-        }
-    }
-
-
-    /**
-     * Method for waiting until GobPie configuration file is created or modified to satisfy the requirements.
-     */
-
-    private static void waitForGobPieConf() {
-
-        // wait until GobPie configuration file is created before continuing
-        WatchService watchService;
-        try {
-            watchService = FileSystems.getDefault().newWatchService();
-            Path path = Paths.get(System.getProperty("user.dir"));
-            path.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
-            WatchKey key;
-            while ((key = watchService.take()) != null) {
-                for (WatchEvent<?> event : key.pollEvents()) {
-                    if ((event.context()).equals(Paths.get(gobPieConfFileName))) {
-                        return;
-                    }
-                }
-                key.reset();
-            }
-        } catch (IOException | InterruptedException e) {
-            String message = "Waiting for GobPie configuration file failed.";
-            forwardErrorMessageToClient(message, message + e.getMessage());
-        }
-
     }
 
 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -109,10 +109,12 @@ public class Main {
         Either<ServerAnalysis, ToolAnalysis> analysis = Either.forLeft(serverAnalysis);
         magpieServer.addAnalysis(analysis, language);
 
-        // add HTTP server for showing CFGs
-        String httpServerAddress = new GobPieHTTPServer(goblintService).start();
-        magpieServer.addHttpServer(httpServerAddress);
-        magpieServer.addCommand("showcfg", new ShowCFGCommand(httpServerAddress));
+        // add HTTP server for showing CFGs, only if the option is specified in the configuration
+        if (gobpieConfiguration.getshowCfg() != null && gobpieConfiguration.getshowCfg()) {
+            String httpServerAddress = new GobPieHTTPServer(goblintService).start();
+            magpieServer.addHttpServer(httpServerAddress);
+            magpieServer.addCommand("showcfg", new ShowCFGCommand(httpServerAddress));
+        }
     }
 
 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -1,3 +1,4 @@
+import HTTPserver.GobPieHTTPServer;
 import analysis.GoblintAnalysis;
 import analysis.ShowCFGCommand;
 import api.GoblintService;
@@ -28,7 +29,6 @@ import java.nio.file.*;
 public class Main {
 
     private static final String gobPieConfFileName = "gobpie.json";
-    private static final String cfgHttpServer = "http://localhost:8080/";
     private static final Logger log = LogManager.getLogger(Main.class);
     private static MagpieServer magpieServer;
 
@@ -68,6 +68,7 @@ public class Main {
         // set up configuration for MagpieServer
         ServerConfiguration serverConfig = new ServerConfiguration();
         serverConfig.setDoAnalysisByFirstOpen(false);
+        serverConfig.setUseMagpieHTTPServer(false);
         magpieServer = new MagpieServer(serverConfig);
     }
 
@@ -113,8 +114,9 @@ public class Main {
         magpieServer.addAnalysis(analysis, language);
 
         // add HTTP server for showing CFGs
-        magpieServer.addHttpServer(cfgHttpServer);
-        magpieServer.addCommand("showcfg", new ShowCFGCommand(goblintService));
+        String httpServerAddress = new GobPieHTTPServer(goblintService).start();
+        magpieServer.addHttpServer(httpServerAddress);
+        magpieServer.addCommand("showcfg", new ShowCFGCommand(httpServerAddress));
     }
 
 
@@ -203,7 +205,7 @@ public class Main {
             WatchKey key;
             while ((key = watchService.take()) != null) {
                 for (WatchEvent<?> event : key.pollEvents()) {
-                    if (((Path) event.context()).equals(Paths.get(gobPieConfFileName))) {
+                    if ((event.context()).equals(Paths.get(gobPieConfFileName))) {
                         return;
                     }
                 }

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -169,13 +169,16 @@ public class GoblintAnalysis implements ServerAnalysis {
                         throw new GobPieException("Analysis returned VerifyError.", GobPieExceptionType.GOBLINT_EXCEPTION);
                     // Get warning messages
                     CompletableFuture<List<GoblintMessagesResult>> messagesTask = goblintService.messages();
-                    // Get list of functions
-                    CompletableFuture<List<GoblintFunctionsResult>> functionsTask = goblintService.functions();
-                    return messagesTask.thenCombine(functionsTask, (messages, functions) ->
-                            Stream.concat(
-                                            convertMessagesFromJson(messages).stream(),
-                                            convertFunctionsFromJson(functions).stream())
-                                    .collect(Collectors.toList()));
+                    if (gobpieConfiguration.getshowCfg() != null && gobpieConfiguration.getshowCfg()) {
+                        // Get list of functions
+                        CompletableFuture<List<GoblintFunctionsResult>> functionsTask = goblintService.functions();
+                        return messagesTask.thenCombine(functionsTask, (messages, functions) ->
+                                Stream.concat(
+                                                convertMessagesFromJson(messages).stream(),
+                                                convertFunctionsFromJson(functions).stream())
+                                        .collect(Collectors.toList()));
+                    }
+                    return messagesTask.thenApply(this::convertMessagesFromJson);
                 });
 
     }

--- a/src/main/java/analysis/ShowCFGCommand.java
+++ b/src/main/java/analysis/ShowCFGCommand.java
@@ -1,33 +1,36 @@
 package analysis;
 
+import com.google.common.io.CharStreams;
 import com.google.gson.JsonPrimitive;
-import api.GoblintService;
-import api.messages.GoblintCFGResult;
-import api.messages.Params;
-import gobpie.GobPieException;
-import gobpie.GobPieExceptionType;
-import guru.nidi.graphviz.engine.Format;
-import guru.nidi.graphviz.engine.Graphviz;
+
 import magpiebridge.core.MagpieClient;
 import magpiebridge.core.MagpieServer;
 import magpiebridge.core.WorkspaceCommand;
+;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+
+import org.apache.http.impl.client.HttpClients;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.URISyntaxException;
-import java.util.concurrent.ExecutionException;
+import java.nio.charset.StandardCharsets;
 
 public class ShowCFGCommand implements WorkspaceCommand {
 
-    private final GoblintService goblintService;
+    private final String httpServerAddress;
     private final Logger log = LogManager.getLogger(ShowCFGCommand.class);
 
-    public ShowCFGCommand(GoblintService goblintService) {
-        this.goblintService = goblintService;
+    public ShowCFGCommand(String httpServerAddress) {
+        this.httpServerAddress = httpServerAddress;
     }
 
     @Override
@@ -40,30 +43,11 @@ public class ShowCFGCommand implements WorkspaceCommand {
             } else {
                 funName = (String) uriJson;
             }
-            log.info("Showing CFG for function: " + funName);
-            String cfg = getCFG(funName);
-            showHTMLinClientOrBrowser(server, client, cfg);
+            showHTMLinClientOrBrowser(server, client, funName);
         } catch (IOException | URISyntaxException e) {
             MagpieServer.ExceptionLogger.log(e);
             e.printStackTrace();
-        }
-    }
-
-    /**
-     * Sends the request to get the cfg for the given function.
-     *
-     * @param funName The function name for which the CFG was requested.
-     * @return the CFG of the given function as a dot language string.
-     * @throws GobPieException if the request and response ID do not match.
-     */
-
-    public String getCFG(String funName) {
-        Params params = new Params(funName);
-        try {
-            GoblintCFGResult cfgResponse = goblintService.cfg(params).get();
-            return cfgResponse.getCfg();
-        } catch (ExecutionException | InterruptedException e) {
-            throw new GobPieException("Sending the request to or receiving result from the server failed.", e, GobPieExceptionType.GOBLINT_EXCEPTION);
+            log.error(e);
         }
     }
 
@@ -71,38 +55,18 @@ public class ShowCFGCommand implements WorkspaceCommand {
     /**
      * Show A HTML page with the given CFG in the client, or in a browser if the client doesn't support this.
      *
-     * @param server The MagpieServer
-     * @param client The IDE/Editor
-     * @param cfg    The CFG which should be shown
+     * @param server  The MagpieServer
+     * @param client  The IDE/Editor
+     * @param funName The name of the function to show the CFG for
      * @throws IOException        IO exception
      * @throws URISyntaxException URI exception
      */
 
-    public static void showHTMLinClientOrBrowser(MagpieServer server, LanguageClient client, String cfg) throws IOException, URISyntaxException {
+    public void showHTMLinClientOrBrowser(MagpieServer server, LanguageClient client, String funName) throws IOException, URISyntaxException {
         if (server.clientSupportShowHTML()) {
             if (client instanceof MagpieClient) {
-                // Generate svg from dot using graphviz-java
-                ByteArrayOutputStream output = new ByteArrayOutputStream();
-                Graphviz.fromString(cfg).render(Format.SVG).toOutputStream(output);
-                String svg = output.toString();
-                // TODO: improve this HTML horror?
-                String content =
-                        "<!DOCTYPE html>\n" +
-                                "<html lang=\"en\"\">\n" +
-                                "   <head>\n" +
-                                "       <meta charset=\"UTF-8\">\n" +
-                                "       <title>Preview</title>\n" +
-                                "       <style>\n" +
-                                "          html { width: 100%; height: 100%; min-height: 100%; display: flex; }\n" +
-                                "          body { flex: 1; display: flex; }\n" +
-                                "          iframe { flex: 1; border: none; background: white; }\n" +
-                                "       </style>\n" +
-                                "   </head>\n" +
-                                "   <body>\n" +
-                                /*"       <img src=\"data:image/svg+xml;base64," + imageAsBase64 + "\" />" +*/
-                                "       <svg>" + svg + "</svg>" +
-                                "   </body>\n" +
-                                "</html>";
+                String json = "{\"funName\": \"" + funName + "\"}";
+                String content = httpPostJson(httpServerAddress + "cfg/", json);
                 ((MagpieClient) client).showHTML(content);
             }
         } /*else {
@@ -111,5 +75,27 @@ public class ShowCFGCommand implements WorkspaceCommand {
                 Desktop.getDesktop().browse(new URI(URIUtils.checkURI(cfg)));
         }*/
     }
+
+
+    /**
+     * Sends the request to get the HTML for visualizing the CFG.
+     *
+     * @param url  The HTTPServer url to post the request to.
+     * @param json The request body as a JSON.
+     * @return The response body as a string.
+     * @throws IOException in case of a problem or the connection was aborted.
+     */
+
+    public static String httpPostJson(String url, String json) throws IOException {
+        CloseableHttpClient httpClient = HttpClients.createDefault();
+        HttpPost httpPost = new HttpPost(url);
+        httpPost.setEntity(new StringEntity(json, ContentType.APPLICATION_JSON));
+        HttpResponse response = httpClient.execute(httpPost);
+        String responseBody = CharStreams.toString(new InputStreamReader(response.getEntity().getContent(), StandardCharsets.UTF_8));
+        httpClient.close();
+        return responseBody;
+    }
+
+
 }
 

--- a/src/main/java/api/GoblintService.java
+++ b/src/main/java/api/GoblintService.java
@@ -20,10 +20,12 @@ import java.util.concurrent.CompletableFuture;
 public interface GoblintService {
 
     // Examples of requests used in this project:
+    // {"jsonrpc":"2.0","id":0,"method":"read_config","params":{"fname":"goblint.json"}}
     // {"jsonrpc":"2.0","id":0,"method":"analyze","params":{}}
     // {"jsonrpc":"2.0","id":0,"method":"messages"}
     // {"jsonrpc":"2.0","id":0,"method":"functions"}
     // {"jsonrpc":"2.0","id":0,"method":"cfg", "params":{"fname":"main"}}
+    // {"jsonrpc":"2.0","id":0,"method":"node_state","params":{"nid":"fun2783"}}
 
     // Examples of responses for the requests:
     // method: "analyze" response:

--- a/src/main/java/api/GoblintService.java
+++ b/src/main/java/api/GoblintService.java
@@ -1,5 +1,6 @@
 package api;
 
+import HTTPserver.GobPieHttpHandler;
 import api.messages.*;
 import com.google.gson.JsonObject;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
@@ -50,7 +51,7 @@ public interface GoblintService {
     CompletableFuture<GoblintCFGResult> cfg(Params params);
 
     @JsonRequest
-    CompletableFuture<List<JsonObject>> node_state(Params params);
+    CompletableFuture<List<JsonObject>> node_state(GobPieHttpHandler.NodeParams params);
 
     @JsonRequest
     CompletableFuture<Void> reset_config();

--- a/src/main/java/api/GoblintService.java
+++ b/src/main/java/api/GoblintService.java
@@ -1,7 +1,7 @@
 package api;
 
-import com.google.gson.JsonObject;
 import api.messages.*;
+import com.google.gson.JsonObject;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 
 import java.util.List;
@@ -48,6 +48,9 @@ public interface GoblintService {
 
     @JsonRequest
     CompletableFuture<GoblintCFGResult> cfg(Params params);
+
+    @JsonRequest
+    CompletableFuture<List<JsonObject>> node_state(Params params);
 
     @JsonRequest
     CompletableFuture<Void> reset_config();

--- a/src/main/java/gobpie/GobPieConfReader.java
+++ b/src/main/java/gobpie/GobPieConfReader.java
@@ -1,0 +1,136 @@
+package gobpie;
+
+import com.google.gson.*;
+import magpiebridge.core.MagpieServer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.*;
+
+public class GobPieConfReader {
+
+    private final MagpieServer magpieServer;
+    private final String gobPieConfFileName;
+    private static final Logger log = LogManager.getLogger(GobPieConfReader.class);
+
+    public GobPieConfReader(MagpieServer magpieServer, String gobPieConfFileName) {
+        this.magpieServer = magpieServer;
+        this.gobPieConfFileName = gobPieConfFileName;
+    }
+
+    /**
+     * Method for reading GobPie configuration.
+     * <p>
+     * Waits for the Gobpie configuration file to be created if one is not present in the project root.
+     * Checks if all the required parameters are present in the configuration and
+     * if not, waits for the file to be changed and reparses it until the user gives the parameters.
+     *
+     * @return GobPieConfiguration object.
+     */
+    public GobPieConfiguration readGobPieConfiguration() {
+
+        // If gobpie configuration is not present, wait for it to be created
+        if (!new File(System.getProperty("user.dir") + "/" + gobPieConfFileName).exists()) {
+            String message = "GobPie configuration file is not found in the project root.";
+            String terminalMessage = message + "\nPlease add GobPie configuration file into the project root.";
+            forwardErrorMessageToClient(message, terminalMessage);
+            waitForGobPieConf();
+        }
+
+        // Parse the configuration file
+        GobPieConfiguration gobpieConfiguration = parseGobPieConf();
+
+        // Check if all required parameters have been set
+        // If not, wait for change and reparse
+        String goblintConf = gobpieConfiguration.getGoblintConf();
+        while (goblintConf == null || goblintConf.equals("")) {
+            String message = "goblintConf parameter missing from GobPie configuration file.";
+            String terminalMessage = message + "\nPlease add Goblint configuration file location into GobPie configuration as a parameter with name \"goblintConf\".";
+            forwardErrorMessageToClient(message, terminalMessage);
+            waitForGobPieConf();
+            gobpieConfiguration = parseGobPieConf();
+            goblintConf = gobpieConfiguration.getGoblintConf();
+        }
+
+        return gobpieConfiguration;
+
+    }
+
+    /**
+     * Method for waiting until GobPie configuration file is created or modified to satisfy the requirements.
+     */
+
+    private void waitForGobPieConf() {
+
+        // wait until GobPie configuration file is created before continuing
+        WatchService watchService;
+        try {
+            watchService = FileSystems.getDefault().newWatchService();
+            Path path = Paths.get(System.getProperty("user.dir"));
+            path.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
+            WatchKey key;
+            while ((key = watchService.take()) != null) {
+                for (WatchEvent<?> event : key.pollEvents()) {
+                    if ((event.context()).equals(Paths.get(gobPieConfFileName))) {
+                        return;
+                    }
+                }
+                key.reset();
+            }
+        } catch (IOException | InterruptedException e) {
+            String message = "Waiting for GobPie configuration file failed.";
+            forwardErrorMessageToClient(message, message + e.getMessage());
+        }
+
+    }
+
+
+    /**
+     * Method for parsing GobPie configuration.
+     * Deserializes json to GobPieConfiguration object.
+     *
+     * @return GobPieConfiguration object.
+     * @throws GobPieException if
+     *                         <ul>
+     *                             <li>gobpie conf cannot be found to be read from;</li>
+     *                             <li>gobpie conf json syntax is wrong.</li>
+     *                         </ul>
+     */
+
+    private GobPieConfiguration parseGobPieConf() {
+        try {
+            log.debug("Reading GobPie configuration from json");
+            Gson gson = new GsonBuilder().create();
+            // Read json object
+            JsonObject jsonObject = JsonParser.parseReader(new FileReader(gobPieConfFileName)).getAsJsonObject();
+            // Convert json object to GobPieConfiguration object
+            log.debug("GobPie configuration read from json");
+            return gson.fromJson(jsonObject, GobPieConfiguration.class);
+        } catch (FileNotFoundException e) {
+            throw new GobPieException("Could not locate GobPie configuration file.", e, GobPieExceptionType.GOBPIE_CONF_EXCEPTION);
+        } catch (JsonSyntaxException e) {
+            throw new GobPieException("GobPie configuration file syntax is wrong.", e, GobPieExceptionType.GOBPIE_CONF_EXCEPTION);
+        }
+    }
+
+    /**
+     * Method for forwarding Error messages to MagpieServer.
+     *
+     * @param popUpMessage    The message shown on the pop-up message.
+     * @param terminalMessage The message shown in the terminal.
+     */
+
+    private void forwardErrorMessageToClient(String popUpMessage, String terminalMessage) {
+        magpieServer.forwardMessageToClient(
+                new MessageParams(MessageType.Error, "Unable to start GobPie extension: " + popUpMessage + " Please check the output terminal of GobPie extension for more information.")
+        );
+        log.error(terminalMessage);
+    }
+
+}

--- a/src/main/java/gobpie/GobPieConfReader.java
+++ b/src/main/java/gobpie/GobPieConfReader.java
@@ -24,6 +24,7 @@ public class GobPieConfReader {
         this.gobPieConfFileName = gobPieConfFileName;
     }
 
+
     /**
      * Method for reading GobPie configuration.
      * <p>
@@ -61,6 +62,7 @@ public class GobPieConfReader {
         return gobpieConfiguration;
 
     }
+
 
     /**
      * Method for waiting until GobPie configuration file is created or modified to satisfy the requirements.
@@ -118,6 +120,7 @@ public class GobPieConfReader {
             throw new GobPieException("GobPie configuration file syntax is wrong.", e, GobPieExceptionType.GOBPIE_CONF_EXCEPTION);
         }
     }
+
 
     /**
      * Method for forwarding Error messages to MagpieServer.

--- a/src/main/java/gobpie/GobPieConfiguration.java
+++ b/src/main/java/gobpie/GobPieConfiguration.java
@@ -23,4 +23,6 @@ public class GobPieConfiguration {
         return this.preAnalyzeCommand;
     }
 
+    // TODO: make showCFG command optional
+
 }

--- a/src/main/java/gobpie/GobPieConfiguration.java
+++ b/src/main/java/gobpie/GobPieConfiguration.java
@@ -13,6 +13,7 @@ public class GobPieConfiguration {
 
     private String goblintConf;
     private String[] preAnalyzeCommand;
+    private Boolean showCfg;
 
     public String getGoblintConf() {
         return this.goblintConf;
@@ -23,6 +24,8 @@ public class GobPieConfiguration {
         return this.preAnalyzeCommand;
     }
 
-    // TODO: make showCFG command optional
+    public Boolean getshowCfg() {
+        return this.showCfg;
+    }
 
 }

--- a/src/main/resources/json-viewer/jquery.json-viewer.css
+++ b/src/main/resources/json-viewer/jquery.json-viewer.css
@@ -1,0 +1,65 @@
+/* Root element */
+.json-document {
+    padding: 1em 2em;
+    font-family: 'Alegreya Sans', sans-serif;
+}
+
+/* Syntax highlighting for JSON objects */
+ul.json-dict, ol.json-array {
+    list-style-type: none;
+    margin: 0 0 0 1px;
+    border-left: 1px dotted #ccc;
+    padding-left: 2em;
+}
+
+.json-string {
+    color: #0B7500;
+}
+
+.json-literal {
+    color: #1A01CC;
+    font-weight: bold;
+}
+
+/* Toggle button */
+a.json-toggle {
+    position: relative;
+    color: inherit;
+    text-decoration: none;
+}
+
+a.json-toggle:focus {
+    outline: none;
+}
+
+a.json-toggle:before {
+    font-size: 1.1em;
+    color: #c0c0c0;
+    content: "\25BC"; /* down arrow */
+    position: absolute;
+    display: inline-block;
+    width: 1em;
+    text-align: center;
+    line-height: 1em;
+    left: -1.2em;
+}
+
+a.json-toggle:hover:before {
+    color: #aaa;
+}
+
+a.json-toggle.collapsed:before {
+    /* Use rotated down arrow, prevents right arrow appearing smaller than down arrow in some browsers */
+    transform: rotate(-90deg);
+}
+
+/* Collapsable placeholder links */
+a.json-placeholder {
+    color: #aaa;
+    padding: 0 1em;
+    text-decoration: none;
+}
+
+a.json-placeholder:hover {
+    text-decoration: underline;
+}

--- a/src/main/resources/json-viewer/jquery.json-viewer.js
+++ b/src/main/resources/json-viewer/jquery.json-viewer.js
@@ -1,0 +1,175 @@
+/**
+ * jQuery json-viewer
+ * @author: Alexandre Bodelot <alexandre.bodelot@gmail.com>
+ * @link: https://github.com/abodelot/jquery.json-viewer
+ */
+(function ($) {
+
+    /**
+     * Check if arg is either an array with at least 1 element, or a dict with at least 1 key
+     * @return boolean
+     */
+    function isCollapsable(arg) {
+        return arg instanceof Object && Object.keys(arg).length > 0;
+    }
+
+    /**
+     * Check if a string looks like a URL, based on protocol
+     * This doesn't attempt to validate URLs, there's no use and syntax can be too complex
+     * @return boolean
+     */
+    function isUrl(string) {
+        const protocols = ['http', 'https', 'ftp', 'ftps'];
+        for (let i = 0; i < protocols.length; ++i) {
+            if (string.startsWith(protocols[i] + '://')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Return the input string html escaped
+     * @return string
+     */
+    function htmlEscape(s) {
+        return s.replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/'/g, '&apos;')
+            .replace(/"/g, '&quot;');
+    }
+
+    /**
+     * Transform a json object into html representation
+     * @return string
+     */
+    function json2html(json, options) {
+        let html = '';
+        if (typeof json === 'string') {
+            // Escape tags and quotes
+            json = htmlEscape(json);
+
+            if (options.withLinks && isUrl(json)) {
+                html += '<a href="' + json + '" class="json-string" target="_blank">' + json + '</a>';
+            } else {
+                // Escape double quotes in the rendered non-URL string.
+                json = json.replace(/&quot;/g, '\\&quot;');
+                html += '<span class="json-string">' + json + '</span>';
+            }
+        } else if (typeof json === 'number' || typeof json === 'bigint') {
+            html += '<span class="json-literal">' + json + '</span>';
+        } else if (typeof json === 'boolean') {
+            html += '<span class="json-literal">' + json + '</span>';
+        } else if (json === null) {
+            html += '<span class="json-literal">null</span>';
+        } else if (json instanceof Array) {
+            if (json.length > 0) {
+                html += '[<ol class="json-array">';
+                for (let i = 0; i < json.length; ++i) {
+                    html += '<li>';
+                    // Add toggle button if item is collapsable
+                    if (isCollapsable(json[i])) {
+                        html += '<a href class="json-toggle"></a>';
+                    }
+                    html += json2html(json[i], options);
+                    // Add comma if item is not last
+                    if (i < json.length - 1) {
+                        html += ',';
+                    }
+                    html += '</li>';
+                }
+                html += '</ol>]';
+            } else {
+                html += '<span class="json-string">∅</span>'; // []
+            }
+        } else if (typeof json === 'object') {
+            // Optional support different libraries for big numbers
+            // json.isLosslessNumber: package lossless-json
+            // json.toExponential(): packages bignumber.js, big.js, decimal.js, decimal.js-light, others?
+            if (options.bigNumbers && (typeof json.toExponential === 'function' || json.isLosslessNumber)) {
+                html += '<span class="json-literal">' + json.toString() + '</span>';
+            } else {
+                let keyCount = Object.keys(json).length;
+                if (keyCount > 0) {
+                    html += '{<ul class="json-dict">';
+                    for (let key in json) {
+                        if (Object.prototype.hasOwnProperty.call(json, key)) {
+                            key = htmlEscape(key);
+                            const keyRepr = options.withQuotes ? '<span class="json-string">"' + key + '"</span>' : key;
+                            html += '<li>';
+                            // Add toggle button if item is collapsable
+                            if (isCollapsable(json[key])) {
+                                html += '<a href class="json-toggle">' + keyRepr + '</a>';
+                            } else {
+                                html += keyRepr;
+                            }
+                            html += ': ' + json2html(json[key], options);
+                            // Add comma if item is not last
+                            if (--keyCount > 0) {
+                                html += ',';
+                            }
+                            html += '</li>';
+                        }
+                    }
+                    html += '</ul>}';
+                } else {
+                    html += '<span class="json-string">∅</span>'; // {}
+                }
+            }
+        }
+        return html;
+    }
+
+    /**
+     * jQuery plugin method
+     * @param json: a javascript object
+     * @param options: an optional options hash
+     */
+    $.fn.jsonViewer = function (json, options) {
+        // Merge user options with default options
+        options = Object.assign({}, {
+            collapsed: false, rootCollapsable: true, withQuotes: false, withLinks: true, bigNumbers: false
+        }, options);
+
+        // jQuery chaining
+        return this.each(function () {
+
+            // Transform to HTML
+            let html = json2html(json, options);
+            if (options.rootCollapsable && isCollapsable(json)) {
+                html = '<a href class="json-toggle"></a>' + html;
+            }
+
+            // Insert HTML in target DOM element
+            $(this).html(html);
+            $(this).addClass('json-document');
+
+            // Bind click on toggle buttons
+            $(this).off('click');
+            $(this).on('click', 'a.json-toggle', function () {
+                const target = $(this).toggleClass('collapsed').siblings('ul.json-dict, ol.json-array');
+                target.toggle();
+                if (target.is(':visible')) {
+                    target.siblings('.json-placeholder').remove();
+                } else {
+                    const count = target.children('li').length;
+                    const placeholder = count + (count > 1 ? ' items' : ' item');
+                    target.after('<a href class="json-placeholder">' + placeholder + '</a>');
+                }
+                return false;
+            });
+
+            // Simulate click on toggle button when placeholder is clicked
+            $(this).on('click', 'a.json-placeholder', function () {
+                $(this).siblings('a.json-toggle').click();
+                return false;
+            });
+
+            if (options.collapsed === true) {
+                // Trigger click to collapse all nodes
+                $(this).find('a.json-toggle').click();
+            }
+        });
+    };
+})($);

--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+<html lang="en"
+      xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Goblint Analysis</title>
+    <style>
+        html {
+            width: 100%;
+            height: 100%;
+            min-height: 100%;
+            display: flex;
+        }
+
+        body {
+            flex: 1;
+            display: flex;
+        }
+
+        iframe {
+            flex: 1;
+            border: none;
+        }
+    </style>
+    <script th:inline="javascript">
+        function sendPostRequest(url, data) {
+            fetch(url, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(data),
+            }).then((response) => response.text())
+                .then(function (data) {
+                    console.log('Success:', data);
+                    document.getElementById("json").textContent = JSON.stringify(JSON.parse(data), null, 4);
+                }).catch((error) => {
+                console.error('Error:', error);
+            });
+        }
+
+        function sendGetRequest(url) {
+            fetch(url, {
+                method: 'get',
+            }).then(function (response) {
+                return response.text();
+            }).then(function (text) {
+                document.write(text)
+            }).catch(function (err) {
+                // Error :(
+            });
+        }
+
+        function show_info(node) {
+            const url = [[${url}]]
+            sendPostRequest(url, JSON.parse(JSON.stringify({node: node})));
+        }
+    </script>
+</head>
+<body>
+<div id='cfg'>
+    [(${cfgSvg})]
+</div>
+<pre id='json'></pre>
+</body>
+</html>

--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -53,8 +53,7 @@
         }
 
         function show_info(node) {
-            const url = [[${url}]]
-            sendPostRequest(url, JSON.parse(JSON.stringify({node: node})));
+            sendPostRequest([[${url}]], JSON.parse(JSON.stringify({node: node})));
         }
     </script>
 </head>

--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -57,7 +57,7 @@
         }
 
         function show_info(node) {
-            sendPostRequest([[${url}]], JSON.parse(JSON.stringify({node: node})));
+            sendPostRequest([[${url}]], {node: node});
         }
     </script>
 </head>

--- a/src/main/resources/templates/base.html
+++ b/src/main/resources/templates/base.html
@@ -23,7 +23,11 @@
             border: none;
         }
     </style>
+    <link th:href="${jsonTreeCss}" type="text/css" rel="stylesheet"/>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.1/jquery.min.js"></script>
+    <script th:src="${jsonTreeJs}" type="text/javascript"></script>
     <script th:inline="javascript">
+
         function sendPostRequest(url, data) {
             fetch(url, {
                 method: 'POST',
@@ -34,7 +38,7 @@
             }).then((response) => response.text())
                 .then(function (data) {
                     console.log('Success:', data);
-                    document.getElementById("json").textContent = JSON.stringify(JSON.parse(data), null, 4);
+                    $('#json').jsonViewer(JSON.parse(data));
                 }).catch((error) => {
                 console.error('Error:', error);
             });

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html SYSTEM "http://www.thymeleaf.org/dtd/xhtml1-strict-thymeleaf-4.dtd">
+<html lang="en"
+      xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Goblint Analysis</title>
+</head>
+<body>
+<div>
+    <p> Goblint analysis homepage. There's nothing much here yet. </p>
+</div>
+</body>
+</html>

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -62,11 +62,10 @@
     "xmlhttprequest-ts": "^1.0.1"
   },
   "devDependencies": {
-    "@vscode/test-electron": "^2.1.4",
+    "@vscode/test-electron": "^2.2.0",
     "@types/vscode": "^1.1.37",
-    "@types/mocha": "^9.1.1",
-    "@types/node": "^18.6.1",
-    "tslint": "^6.1.3",
-    "typescript": "^4.7.4"
+    "@types/mocha": "^10.0.0",
+    "@types/node": "^18.11.4",
+    "typescript": "^4.8.4"
   }
 }


### PR DESCRIPTION
Closes #38.

The functionality to show states for CFG nodes:
* Uses an HTTP server to communicate with the "frontend"
* I opted for Thymeleaf templates for the HTML and JS 

### TODO:
- [x] Make the code actions for showing CFGs optional through GobPie configuration because it can make the code look crowded and it would be nice to be able to turn them off.
- [x] The node state request does not work for the start and end nodes