### PR TITLE
Recover Goblint server automatically after crashing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,13 @@
             <version>3.0.15.RELEASE</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/io.methvin/directory-watcher -->
+        <dependency>
+            <groupId>io.methvin</groupId>
+            <artifactId>directory-watcher</artifactId>
+            <version>0.17.1</version>
+        </dependency>
+
 
         <!-- log4j -->
         <dependency>

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -102,7 +102,12 @@ public class Main {
         GoblintService goblintService = localEndpoint.getServer();
 
         // read Goblint configurations
-        goblintService.read_config(new Params(new File(goblintServer.getGoblintConf()).getAbsolutePath()));
+        goblintService.read_config(new Params(new File(goblintServer.getGoblintConf()).getAbsolutePath()))
+                .whenComplete((res, ex) -> {
+                    String msg = "Goblint was unable to successfully read the new configuration. " + ex.getMessage();
+                    magpieServer.forwardMessageToClient(new MessageParams(MessageType.Warning, msg));
+                    log.error(msg);
+                });
 
         // add analysis to the MagpieServer
         ServerAnalysis serverAnalysis = new GoblintAnalysis(magpieServer, goblintServer, goblintService, gobpieConfiguration);

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -152,7 +152,6 @@ public class GoblintAnalysis implements ServerAnalysis {
         }
     }
 
-
     /**
      * Sends the requests to Goblint server and gets their results.
      * Checks if analysis succeeded.
@@ -264,9 +263,12 @@ public class GoblintAnalysis implements ServerAnalysis {
                     magpieServer.exit();
                 } else {
                     goblintService.reset_config();
-                    goblintService.read_config(new Params(new File(goblintServer.getGoblintConf()).getAbsolutePath()));
-                    // TODO: notify user when the conf was changed but not successfully read by Goblint
-                    // e.g. {"id":0,"jsonrpc":"2.0","error":{"code":-32603,"message":"Json_encoding: Unexpected object field ..."}}
+                    goblintService.read_config(new Params(new File(goblintServer.getGoblintConf()).getAbsolutePath()))
+                            .whenComplete((res, ex) -> {
+                                String msg = "Goblint was unable to successfully read the new configuration. " + ex.getMessage();
+                                magpieServer.forwardMessageToClient(new MessageParams(MessageType.Warning, msg));
+                                log.error(msg);
+                            });
                 }
             }
         });

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -1,10 +1,7 @@
 package analysis;
 
 import api.GoblintService;
-import api.messages.GoblintAnalysisResult;
-import api.messages.GoblintFunctionsResult;
-import api.messages.GoblintMessagesResult;
-import api.messages.Params;
+import api.messages.*;
 import com.ibm.wala.classLoader.Module;
 import goblintserver.GoblintServer;
 import gobpie.GobPieConfiguration;
@@ -35,7 +32,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -159,43 +155,58 @@ public class GoblintAnalysis implements ServerAnalysis {
 
     /**
      * Sends the requests to Goblint server and gets their results.
+     * Checks if analysis succeeded.
+     * If analysis succeeds, requests the messages from the Goblint server.
+     * If showCfg option is turned on, asks for the function names for code lenses.
      *
      * @return a CompletableFuture of a collection of warning messages and cfg code lenses if request was successful.
      * @throws GobPieException in case the analysis was aborted or returned a VerifyError.
      */
 
     private CompletableFuture<Collection<AnalysisResult>> reanalyse() {
+        return goblintService.analyze(new Params())
+                .thenCompose(this::getComposedAnalysisResults)
+                .applyToEither(didGoblintCrash(), res -> res);
+    }
 
-        CompletableFuture<Collection<AnalysisResult>> goblintExit = CompletableFuture.supplyAsync(() -> {
+    private void didAnalysisNotSucceed(GoblintAnalysisResult analysisResult) {
+        if (analysisResult.getStatus().contains("Aborted"))
+            throw new GobPieException("The running analysis has been aborted.", GobPieExceptionType.GOBLINT_EXCEPTION);
+        else if (analysisResult.getStatus().contains("VerifyError"))
+            throw new GobPieException("Analysis returned VerifyError.", GobPieExceptionType.GOBLINT_EXCEPTION);
+    }
+
+    private CompletableFuture<Collection<AnalysisResult>> didGoblintCrash() {
+        return CompletableFuture.supplyAsync(() -> {
             try {
                 goblintServer.getGoblintRunProcess().getProcess().waitFor();
             } catch (InterruptedException ignored) {
             }
             throw new GobPieException("Goblint has exited.", GobPieExceptionType.GOBLINT_EXCEPTION);
         });
+    }
 
-        Function<GoblintAnalysisResult, CompletableFuture<Collection<AnalysisResult>>> composeAnalysisResults = analysisResult -> {
-            // Make sure that analysis succeeded
-            if (analysisResult.getStatus().contains("Aborted"))
-                throw new GobPieException("The running analysis has been aborted.", GobPieExceptionType.GOBLINT_EXCEPTION);
-            else if (analysisResult.getStatus().contains("VerifyError"))
-                throw new GobPieException("Analysis returned VerifyError.", GobPieExceptionType.GOBLINT_EXCEPTION);
-            // Get warning messages
-            CompletableFuture<List<GoblintMessagesResult>> messagesTask = goblintService.messages();
-            if (gobpieConfiguration.getshowCfg() != null && gobpieConfiguration.getshowCfg()) {
-                // Get list of functions
-                CompletableFuture<List<GoblintFunctionsResult>> functionsTask = goblintService.functions();
-                return messagesTask.thenCombine(functionsTask, (messages, functions) ->
+    private CompletableFuture<Collection<AnalysisResult>> convertAndCombineResults(
+            CompletableFuture<List<GoblintMessagesResult>> messagesCompletableFuture,
+            CompletableFuture<List<GoblintFunctionsResult>> functionsCompletableFuture) {
+        return messagesCompletableFuture
+                .thenCombine(functionsCompletableFuture, (messages, functions) ->
                         Stream.concat(
-                                        convertMessagesFromJson(messages).stream(),
-                                        convertFunctionsFromJson(functions).stream())
-                                .collect(Collectors.toList()));
-            }
-            return messagesTask.thenApply(this::convertMessagesFromJson);
-        };
+                                convertMessagesFromJson(messages).stream(),
+                                convertFunctionsFromJson(functions).stream()
+                        ).collect(Collectors.toList()));
+    }
 
-        return goblintService.analyze(new Params()).thenCompose(composeAnalysisResults).applyToEither(goblintExit, res -> res);
-
+    private CompletableFuture<Collection<AnalysisResult>> getComposedAnalysisResults(GoblintAnalysisResult analysisResult) {
+        didAnalysisNotSucceed(analysisResult);
+        // Get warning messages
+        CompletableFuture<List<GoblintMessagesResult>> messagesCompletableFuture = goblintService.messages();
+        if (gobpieConfiguration.getshowCfg() == null || !gobpieConfiguration.getshowCfg()) {
+            return messagesCompletableFuture.thenApply(this::convertMessagesFromJson);
+        }
+        // Get list of functions
+        CompletableFuture<List<GoblintFunctionsResult>> functionsCompletableFuture = goblintService.functions();
+        return convertAndCombineResults(messagesCompletableFuture, functionsCompletableFuture);
     }
 
 
@@ -244,9 +255,7 @@ public class GoblintAnalysis implements ServerAnalysis {
      */
 
     public FileAlterationObserver createGoblintConfObserver() {
-
         FileFilter fileFilter = file -> file.getName().equals(gobpieConfiguration.getGoblintConf());
-
         FileAlterationObserver observer = new FileAlterationObserver(System.getProperty("user.dir"), fileFilter);
         observer.addListener(new FileAlterationListenerAdaptor() {
             @Override

--- a/src/main/java/api/GoblintService.java
+++ b/src/main/java/api/GoblintService.java
@@ -19,45 +19,39 @@ import java.util.concurrent.CompletableFuture;
 
 public interface GoblintService {
 
-    // Examples of requests used in this project:
-    // {"jsonrpc":"2.0","id":0,"method":"read_config","params":{"fname":"goblint.json"}}
-    // {"jsonrpc":"2.0","id":0,"method":"analyze","params":{}}
-    // {"jsonrpc":"2.0","id":0,"method":"messages"}
-    // {"jsonrpc":"2.0","id":0,"method":"functions"}
-    // {"jsonrpc":"2.0","id":0,"method":"cfg", "params":{"fname":"main"}}
-    // {"jsonrpc":"2.0","id":0,"method":"node_state","params":{"nid":"fun2783"}}
-
-    // Examples of responses for the requests:
-    // method: "analyze" response:
-    // {"id":0,"jsonrpc":"2.0","result":{"status":["Success"]}}
-    // method: "messages" response:
-    // {"id":0,"jsonrpc":"2.0","result":[{"tags":[{"Category":["Race"]}], ... }]}
-    // method: "functions" response:
-    // {"id":0,"jsonrpc":"2.0","result":[{"funName":"qsort","location":{"file":"/home/ ... }]}
-    // method: "cfg" response:
-    // {"id":0,"jsonrpc":"2.0","result":{"cfg":"digraph cfg {\n\tnode [id=\"\\N\", ... }}
-
     @JsonRequest
     CompletableFuture<JsonObject> ping();
 
+    // request:  {"jsonrpc":"2.0","id":0,"method":"analyze","params":{}}
+    // response: {"id":0,"jsonrpc":"2.0","result":{"status":["Success"]}}
     @JsonRequest
     CompletableFuture<GoblintAnalysisResult> analyze(Params params);
 
+    // request:  {"jsonrpc":"2.0","id":0,"method":"messages"}
+    // response: {"id":0,"jsonrpc":"2.0","result":[{"tags":[{"Category":["Race"]}], ... }]}
     @JsonRequest
     CompletableFuture<List<GoblintMessagesResult>> messages();
 
+    // request:  {"jsonrpc":"2.0","id":0,"method":"functions"}
+    // response: {"id":0,"jsonrpc":"2.0","result":[{"funName":"qsort","location":{"file":"/home/ ... }]}
     @JsonRequest
     CompletableFuture<List<GoblintFunctionsResult>> functions();
 
+    // request:  {"jsonrpc":"2.0","id":0,"method":"cfg", "params":{"fname":"main"}}
+    // response: {"id":0,"jsonrpc":"2.0","result":{"cfg":"digraph cfg {\n\tnode [id=\"\\N\", ... }}
     @JsonRequest
     CompletableFuture<GoblintCFGResult> cfg(Params params);
 
+    // request:  {"jsonrpc":"2.0","id":0,"method":"node_state","params":{"nid":"fun2783"}}
     @JsonRequest
     CompletableFuture<List<JsonObject>> node_state(GobPieHttpHandler.NodeParams params);
 
     @JsonRequest
     CompletableFuture<Void> reset_config();
 
+    // request:  {"jsonrpc":"2.0","id":0,"method":"read_config","params":{"fname":"goblint.json"}}
+    // response: {"id":0,"jsonrpc":"2.0","result":null}
+    //           {"id":0,"jsonrpc":"2.0","error":{"code":-32603,"message":"Json_encoding: Unexpected object field .."}}
     @JsonRequest
     CompletableFuture<Void> read_config(Params params);
 

--- a/src/main/java/api/GoblintServiceLauncher.java
+++ b/src/main/java/api/GoblintServiceLauncher.java
@@ -127,7 +127,7 @@ public class GoblintServiceLauncher implements Launcher<GoblintService> {
 
         public void connectSocketStreams() {
             try {
-                AFUNIXSocket socket = AFUNIXSocket.newInstance();
+                AFUNIXSocket socket = AFUNIXSocket.newInstance(); // TODO: close after
                 socket.connect(AFUNIXSocketAddress.of(new File(goblintSocketName)));
                 outputStream = socket.getOutputStream();
                 inputStream = socket.getInputStream();

--- a/src/main/java/api/util/DirectoryWatchingUtility.java
+++ b/src/main/java/api/util/DirectoryWatchingUtility.java
@@ -1,0 +1,44 @@
+package api.util;
+
+import io.methvin.watcher.DirectoryWatcher;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+public class DirectoryWatchingUtility {
+
+    private final DirectoryWatcher watcher;
+
+    public DirectoryWatchingUtility(Path directoryToWatch) throws IOException {
+        this.watcher = DirectoryWatcher.builder()
+                .path(directoryToWatch) // or use paths(directoriesToWatch)
+                .listener(event -> {
+                    switch (event.eventType()) {
+                        case CREATE:
+                            /* file created */
+                            stopWatching();
+                            return;
+                        case MODIFY:
+                            /* file modified */
+                            break;
+                        case DELETE:
+                            /* file deleted */
+                            break;
+                    }
+                })
+                // .fileHashing(false) // defaults to true
+                // .logger(logger) // defaults to LoggerFactory.getLogger(DirectoryWatcher.class)
+                // .watchService(watchService) // defaults based on OS to either JVM WatchService or the JNA macOS WatchService
+                .build();
+    }
+
+    public void stopWatching() throws IOException {
+        watcher.close();
+    }
+
+    public CompletableFuture<Void> watch() {
+        // you can also use watcher.watch() to block the current thread
+        return watcher.watchAsync();
+    }
+}

--- a/src/main/java/goblintserver/GoblintServer.java
+++ b/src/main/java/goblintserver/GoblintServer.java
@@ -1,5 +1,6 @@
 package goblintserver;
 
+import api.util.DirectoryWatchingUtility;
 import gobpie.GobPieException;
 import magpiebridge.core.MagpieServer;
 import org.apache.logging.log4j.LogManager;
@@ -15,6 +16,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
 import static gobpie.GobPieExceptionType.GOBLINT_EXCEPTION;
@@ -86,28 +88,23 @@ public class GoblintServer {
         try {
             // run command to start goblint
             log.info("Goblint run with command: " + String.join(" ", goblintRunCommand));
-
             goblintRunProcess = runCommand(new File(System.getProperty("user.dir")), goblintRunCommand);
 
             // wait until Goblint socket is created before continuing
             if (!new File(goblintSocket).exists()) {
-                WatchService watchService = FileSystems.getDefault().newWatchService();
-                Path path = Paths.get(System.getProperty("user.dir"));
-                path.register(watchService, StandardWatchEventKinds.ENTRY_CREATE);
-                WatchKey key;
-                while ((key = watchService.take()) != null) {
-                    for (WatchEvent<?> event : key.pollEvents()) {
-                        if ((event.context()).equals(Paths.get(goblintSocket))) {
-                            log.info("Goblint server started.");
-                            return;
-                        }
-                    }
-                    key.reset();
-                }
+                watch();
             }
         } catch (IOException | InvalidExitValueException | InterruptedException | TimeoutException e) {
             throw new GobPieException("Running Goblint failed.", e, GOBLINT_EXCEPTION);
         }
+    }
+
+    private void watch() throws IOException, InterruptedException {
+        Path path = Paths.get(System.getProperty("user.dir"));
+        DirectoryWatchingUtility socketWatchingUtility = new DirectoryWatchingUtility(path);
+        socketWatchingUtility.watch().thenAccept(res -> {
+            log.info("Goblint server started.");
+        });
     }
 
 

--- a/src/main/java/goblintserver/GoblintServer.java
+++ b/src/main/java/goblintserver/GoblintServer.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
 import static gobpie.GobPieExceptionType.GOBLINT_EXCEPTION;
@@ -131,6 +132,8 @@ public class GoblintServer {
                     magpieServer.forwardMessageToClient(new MessageParams(MessageType.Error, "Goblint server exited due to an error. Please check the output terminal of GobPie extension for more information."));
                     log.error("Goblint server exited due to an error (code: " + process.exitValue() + "). Please fix the issue reported above and restart the extension.");
                 }
+                magpieServer.cleanUp();
+                // TODO: throw an exception? where (and how) can it be caught to be handled though?
             }
         };
 

--- a/src/main/java/goblintserver/GoblintServer.java
+++ b/src/main/java/goblintserver/GoblintServer.java
@@ -15,7 +15,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.Arrays;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
 import static gobpie.GobPieExceptionType.GOBLINT_EXCEPTION;


### PR DESCRIPTION
While working on my thesis it has been very annoying that the plugin crashes each time I misspell the file name in the configuration file or make a syntax error in the `.c` file. This PR will try to make the plugin able to recover from most of those cases where Goblint crashes during analysis, so one does not have to restart the plugin manually.

- [x] When Goblint crashes due to `No such file or directory` and Goblint conf is changed, the plugin will try to restart.
- [ ] Try to restart the plugin when Goblint crashes due to a parsing error.
- [x] Notify the user when the new configurations were not read in due to a mistake in the configuration file (e.g. syntax error or missing option).