### PR TITLE
Make test scripts exit on error

### DIFF
--- a/vscode/build_and_test.bat
+++ b/vscode/build_and_test.bat
@@ -1,3 +1,5 @@
 call mvn clean package -f "../pom.xml"
+if %errorlevel% neq 0 exit /b %errorlevel%
 call vsce package
+if %errorlevel% neq 0 exit /b %errorlevel%
 wsl -- bash ./install_and_test.sh

--- a/vscode/build_and_test.sh
+++ b/vscode/build_and_test.sh
@@ -1,3 +1,4 @@
+set -e
 mvn clean package -f "../pom.xml"
 vsce package
 bash ./install_and_test.sh


### PR DESCRIPTION
This fixes a quirk with the test scripts where they would continue on and launch an old version of the extension if compiling or packaging failed.