### PR TITLE
Add config option to disable incremental analysis

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -111,7 +111,7 @@ public class Main {
         magpieServer.addAnalysis(analysis, language);
 
         // add HTTP server for showing CFGs, only if the option is specified in the configuration
-        if (gobpieConfiguration.getshowCfg() != null && gobpieConfiguration.getshowCfg()) {
+        if (gobpieConfiguration.getShowCfg()) {
             String httpServerAddress = new GobPieHTTPServer(goblintService).start();
             magpieServer.addHttpServer(httpServerAddress);
             magpieServer.addCommand("showcfg", new ShowCFGCommand(httpServerAddress));

--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -1,10 +1,7 @@
 package analysis;
 
 import api.GoblintService;
-import api.messages.GoblintAnalysisResult;
-import api.messages.GoblintFunctionsResult;
-import api.messages.GoblintMessagesResult;
-import api.messages.Params;
+import api.messages.*;
 import com.ibm.wala.classLoader.Module;
 import goblintserver.GoblintServer;
 import gobpie.GobPieConfiguration;
@@ -189,7 +186,7 @@ public class GoblintAnalysis implements ServerAnalysis {
      * @throws GobPieException in case the analysis was aborted or returned a VerifyError.
      */
     private CompletableFuture<Collection<AnalysisResult>> reanalyse() {
-        return goblintService.analyze(new Params())
+        return goblintService.analyze(new AnalyzeParams(!gobpieConfiguration.useIncrementalAnalysis()))
                 .thenCompose(this::getComposedAnalysisResults);
     }
 
@@ -215,7 +212,7 @@ public class GoblintAnalysis implements ServerAnalysis {
         didAnalysisNotSucceed(analysisResult);
         // Get warning messages
         CompletableFuture<List<GoblintMessagesResult>> messagesCompletableFuture = goblintService.messages();
-        if (gobpieConfiguration.getshowCfg() == null || !gobpieConfiguration.getshowCfg()) {
+        if (!gobpieConfiguration.getShowCfg()) {
             return messagesCompletableFuture.thenApply(this::convertMessagesFromJson);
         }
         // Get list of functions

--- a/src/main/java/api/GoblintService.java
+++ b/src/main/java/api/GoblintService.java
@@ -25,7 +25,7 @@ public interface GoblintService {
     // request:  {"jsonrpc":"2.0","id":0,"method":"analyze","params":{}}
     // response: {"id":0,"jsonrpc":"2.0","result":{"status":["Success"]}}
     @JsonRequest
-    CompletableFuture<GoblintAnalysisResult> analyze(Params params);
+    CompletableFuture<GoblintAnalysisResult> analyze(AnalyzeParams params);
 
     // request:  {"jsonrpc":"2.0","id":0,"method":"messages"}
     // response: {"id":0,"jsonrpc":"2.0","result":[{"tags":[{"Category":["Race"]}], ... }]}

--- a/src/main/java/api/messages/AnalyzeParams.java
+++ b/src/main/java/api/messages/AnalyzeParams.java
@@ -1,0 +1,11 @@
+package api.messages;
+
+public class AnalyzeParams {
+
+    boolean reset;
+
+    public AnalyzeParams(boolean reset) {
+        this.reset = reset;
+    }
+
+}

--- a/src/main/java/gobpie/GobPieConfiguration.java
+++ b/src/main/java/gobpie/GobPieConfiguration.java
@@ -8,12 +8,13 @@ package gobpie;
  * @author Karoliine Holter
  * @since 0.0.2
  */
-
+@SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
 public class GobPieConfiguration {
 
     private String goblintConf;
     private String[] preAnalyzeCommand;
-    private Boolean showCfg;
+    private boolean showCfg = false;
+    private boolean incrementalAnalysis = true;
 
     public String getGoblintConf() {
         return this.goblintConf;
@@ -24,8 +25,12 @@ public class GobPieConfiguration {
         return this.preAnalyzeCommand;
     }
 
-    public Boolean getshowCfg() {
+    public boolean getShowCfg() {
         return this.showCfg;
+    }
+
+    public boolean useIncrementalAnalysis() {
+        return incrementalAnalysis;
     }
 
 }


### PR DESCRIPTION
This pull request adds an optional config option `incrementalAnalysis` to `gobpie.json`.

If not specified, it defaults to `true`, which is corresponds to the current behavior. If set to `false` it will run Goblint analysis with incremental analysis mostly* disabled.

\* As far as I know the `reset` option for the `analyze` request does not disable incremental analysis but instead clears almost all existing incremental analysis results, which in practice has more or less the same effect as disabling incremental analysis.

This is useful because incremental analysis in server mode can in some cases cause Goblint to crash or return inconsistent results (see for example https://github.com/goblint/analyzer/issues/940).