### PR TITLE
Add config option to set location of goblint executable

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -88,7 +88,7 @@ public class Main {
         GobPieConfiguration gobpieConfiguration = gobPieConfReader.readGobPieConfiguration();
 
         // start GoblintServer
-        GoblintServer goblintServer = new GoblintServer(magpieServer);
+        GoblintServer goblintServer = new GoblintServer(magpieServer, gobpieConfiguration);
         goblintServer.startGoblintServer();
 
         // launch GoblintService

--- a/src/main/java/goblintserver/GoblintServer.java
+++ b/src/main/java/goblintserver/GoblintServer.java
@@ -1,5 +1,6 @@
 package goblintserver;
 
+import gobpie.GobPieConfiguration;
 import gobpie.GobPieException;
 import magpiebridge.core.MagpieServer;
 import org.apache.logging.log4j.LogManager;
@@ -34,6 +35,7 @@ public class GoblintServer {
     private static final String GOBLINT_SOCKET = "goblint.sock";
 
     private final MagpieServer magpieServer;
+    private final GobPieConfiguration configuration;
     private final String[] goblintRunCommand;
 
     private StartedProcess goblintRunProcess;
@@ -41,8 +43,9 @@ public class GoblintServer {
     private final Logger log = LogManager.getLogger(GoblintServer.class);
 
 
-    public GoblintServer(MagpieServer magpieServer) {
+    public GoblintServer(MagpieServer magpieServer, GobPieConfiguration configuration) {
         this.magpieServer = magpieServer;
+        this.configuration = configuration;
         this.goblintRunCommand = constructGoblintRunCommand();
     }
 
@@ -62,13 +65,13 @@ public class GoblintServer {
      * @throws GobPieException when running Goblint failed.
      */
     private String[] constructGoblintRunCommand() {
-        return Arrays.stream(new String[]{
-                        "goblint",
-                        "--enable", "server.enabled",
-                        "--enable", "server.reparse",
-                        "--set", "server.mode", "unix",
-                        "--set", "server.unix-socket", new File(getGoblintSocket()).getAbsolutePath()})
-                .toArray(String[]::new);
+        return new String[]{
+                configuration.getGoblintExecutable(),
+                "--enable", "server.enabled",
+                "--enable", "server.reparse",
+                "--set", "server.mode", "unix",
+                "--set", "server.unix-socket", new File(getGoblintSocket()).getAbsolutePath()
+        };
     }
 
 

--- a/src/main/java/gobpie/GobPieConfiguration.java
+++ b/src/main/java/gobpie/GobPieConfiguration.java
@@ -11,10 +11,15 @@ package gobpie;
 @SuppressWarnings({"FieldMayBeFinal", "FieldCanBeLocal"})
 public class GobPieConfiguration {
 
+    private String goblintExecutable = "goblint";
     private String goblintConf;
     private String[] preAnalyzeCommand;
     private boolean showCfg = false;
     private boolean incrementalAnalysis = true;
+
+    public String getGoblintExecutable() {
+        return this.goblintExecutable;
+    }
 
     public String getGoblintConf() {
         return this.goblintConf;

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -10,7 +10,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="DEBUG"> <!--  change info to debug here to see the debug logs while developing  -->
+        <Root level="INFO"> <!--  change info to debug here to see the debug logs while developing  -->
             <AppenderRef ref="stderr"/>
         </Root>
     </Loggers>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -10,7 +10,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="INFO"> <!--  change info to debug here to see the debug logs while developing  -->
+        <Root level="DEBUG"> <!--  change info to debug here to see the debug logs while developing  -->
             <AppenderRef ref="stderr"/>
         </Root>
     </Loggers>

--- a/vscode/.env.example
+++ b/vscode/.env.example
@@ -1,4 +1,2 @@
-# Location of your Goblint opam switch
-GOBLINT_OPAM_SWITCH=/home/user/goblint/analyzer
 # Location of the folder which will be opened for testing GobPie; should contain C code (for WSL this must be inside the Linux filesystem i.e. not /mnt/**)
 GOBPIE_TEST_PROJECT=/home/user/goblint/example

--- a/vscode/install_and_test.sh
+++ b/vscode/install_and_test.sh
@@ -1,6 +1,5 @@
 # Load environment variables from .env
 export $(grep -v '^#' .env | xargs)
 
-eval $(opam env --switch=$GOBLINT_OPAM_SWITCH --set-switch)
 code --install-extension gobpie-0.0.3.vsix
 code $GOBPIE_TEST_PROJECT


### PR DESCRIPTION
This pull request adds a config option `goblintExecutable`, which sets the location of the goblint executable used to run analyses.

It defaults to `"goblint"` ie. by default it expects that there is an executable named `goblint` on the path. This is done for backwards compatibility reasons.

For use with a goblint executable built from source the correct value should be `/<path_to_analyzer_repo>/goblint`.