### PR TITLE
Fix GobPie not showing error popups during startup and on failed analysis

### DIFF
--- a/src/main/java/GoblintMagpieServer.java
+++ b/src/main/java/GoblintMagpieServer.java
@@ -1,0 +1,48 @@
+import magpiebridge.core.*;
+import magpiebridge.file.SourceFileManager;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import java.util.concurrent.CompletableFuture;
+
+public class GoblintMagpieServer extends MagpieServer {
+
+    /**
+     * Future that is completed once the configuration of the server has completed i.e. all analyses have been added.
+     */
+    private final CompletableFuture<Void> configurationDoneFuture = new CompletableFuture<>();
+
+    /**
+     * Instantiates a new MagpieServer using default {@link MagpieTextDocumentService} and {@link
+     * MagpieWorkspaceService} with given {@link ServerConfiguration}.
+     *
+     * @param config the config
+     */
+    public GoblintMagpieServer(ServerConfiguration config) {
+        super(config);
+    }
+
+    /**
+     * Marks this server instance as fully configured, which allows the initialize request to complete.
+     * The server will receive no communication other than the initialize request from the client before this is called.
+     */
+    public void configurationDone() {
+        configurationDoneFuture.complete(null);
+    }
+
+    @Override
+    public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
+        return super.initialize(params).thenCombine(configurationDoneFuture, (r, _v) -> r);
+    }
+
+    @Override
+    protected void doSingleAnalysis(String language, Either<ServerAnalysis, ToolAnalysis> analysis, boolean rerun) {
+        SourceFileManager fileManager = getSourceFileManager(language);
+        Analysis<AnalysisConsumer> a = analysis.isLeft() ? analysis.getLeft() : analysis.getRight();
+        if (a != null) {
+            a.analyze(fileManager.getSourceFileModules().values(), this, rerun);
+        }
+    }
+
+}

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -24,22 +24,18 @@ public class Main {
 
     private static final String gobPieConfFileName = "gobpie.json";
     private static final Logger log = LogManager.getLogger(Main.class);
-    private static MagpieServer magpieServer;
+    private static GoblintMagpieServer magpieServer;
 
     public static void main(String... args) {
 
         try {
             createMagpieServer();
             addAnalysis();
-            // launch magpieServer
-            magpieServer.launchOnStdio();
+            magpieServer.configurationDone();
             log.info("MagpieBridge server launched.");
-            magpieServer.doAnalysis("c", true);
         } catch (GobPieException e) {
             String message = e.getMessage();
-            String terminalMessage;
-            if (e.getCause() == null) terminalMessage = message;
-            else terminalMessage = message + " Cause: " + e.getCause().getMessage();
+            String terminalMessage = e.getCause() == null ? message : message + " Cause: " + e.getCause().getMessage();
             forwardErrorMessageToClient(message, terminalMessage);
             switch (e.getType()) {
                 case GOBLINT_EXCEPTION:
@@ -61,9 +57,11 @@ public class Main {
     private static void createMagpieServer() {
         // set up configuration for MagpieServer
         ServerConfiguration serverConfig = new ServerConfiguration();
-        serverConfig.setDoAnalysisByFirstOpen(false);
         serverConfig.setUseMagpieHTTPServer(false);
-        magpieServer = new MagpieServer(serverConfig);
+        magpieServer = new GoblintMagpieServer(serverConfig);
+        // launch MagpieServer
+        // note that the server will not accept messages until configurationDone is called
+        magpieServer.launchOnStdio();
     }
 
 

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -126,7 +126,7 @@ public class Main {
 
     private static void forwardErrorMessageToClient(String popUpMessage, String terminalMessage) {
         magpieServer.forwardMessageToClient(
-                new MessageParams(MessageType.Error, "Unable to start GobPie extension: " + popUpMessage + " Please check the output terminal of GobPie extension for more information.")
+                new MessageParams(MessageType.Error, "Unable to start GobPie extension: " + popUpMessage + " Check the output terminal of GobPie extension for more information.")
         );
         log.error(terminalMessage);
     }

--- a/src/main/java/gobpie/GobPieConfReader.java
+++ b/src/main/java/gobpie/GobPieConfReader.java
@@ -116,7 +116,7 @@ public class GobPieConfReader {
 
     private void forwardErrorMessageToClient(String popUpMessage, String terminalMessage) {
         magpieServer.forwardMessageToClient(
-                new MessageParams(MessageType.Error, "Unable to start GobPie extension: " + popUpMessage + " Please check the output terminal of GobPie extension for more information.")
+                new MessageParams(MessageType.Error, "Problem starting GobPie extension: " + popUpMessage + " Check the output terminal of GobPie extension for more information.")
         );
         log.error(terminalMessage);
     }


### PR DESCRIPTION
This pull request fixes https://github.com/goblint/GobPie/issues/49 and some other cases where GobPie does not show error popups to the user even though it probably should.
Error popups are now shown in the following cases:

- On errors that occur during startup, before MagpieServer has been fully configured.
- On errors returned by Goblint in response to the `analyze` request.

Additionally this tweaks some popup related logic to ensure that the 'finished analysing' notification is shown after the analysis has completed and only if the analysis completed successfully.