### PR TITLE
Fix issue #55

### DIFF
--- a/src/main/java/GoblintMagpieServer.java
+++ b/src/main/java/GoblintMagpieServer.java
@@ -33,7 +33,7 @@ public class GoblintMagpieServer extends MagpieServer {
 
     @Override
     public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
-        return super.initialize(params).thenCombine(configurationDoneFuture, (r, _v) -> r);
+        return configurationDoneFuture.thenCompose(_r -> super.initialize(params));
     }
 
     @Override

--- a/src/main/java/gobpie/GobPieConfiguration.java
+++ b/src/main/java/gobpie/GobPieConfiguration.java
@@ -8,16 +8,16 @@ package gobpie;
  * @author Karoliine Holter
  * @since 0.0.2
  */
-@SuppressWarnings({"FieldCanBeLocal"})
 public class GobPieConfiguration {
 
-    private final String goblintExecutable = "goblint";
+    private final String goblintExecutable;
     private String goblintConf;
     private String[] preAnalyzeCommand;
     private final boolean showCfg;
     private final boolean incrementalAnalysis;
 
     private GobPieConfiguration() {
+        goblintExecutable = "goblint";
         showCfg = false;
         incrementalAnalysis = true;
     }


### PR DESCRIPTION
This pull request fixes issue #55 and applies the fix from https://github.com/goblint/GobPie/commit/de3d38b4b094f350a90b722520f84657565cc1b6 to the `goblintExecutable` field.

The issue with `showcfg` was that the list of commands was stored during the MagpieServer initialize method. Calling the MagpieServer initialize method after `configurationDone` has fixed the problem

