### PR TITLE
Use a TypeAdapter to deserialize Multipiece from json and cleanup

### DIFF
--- a/src/main/java/analysis/GoblintAnalysis.java
+++ b/src/main/java/analysis/GoblintAnalysis.java
@@ -244,9 +244,7 @@ public class GoblintAnalysis implements ServerAnalysis {
      */
 
     private Collection<AnalysisResult> convertMessagesFromJson(List<GoblintMessagesResult> response) {
-        return gobpieConfiguration.explodeGroupWarnings()
-                ? response.stream().map(GoblintMessagesResult::convertExplode).flatMap(List::stream).toList()
-                : response.stream().map(GoblintMessagesResult::convertNonExplode).flatMap(List::stream).toList();
+        return response.stream().map(msg -> msg.convert(gobpieConfiguration.explodeGroupWarnings())).flatMap(List::stream).toList();
     }
 
     private Collection<AnalysisResult> convertFunctionsFromJson(List<GoblintFunctionsResult> response) {

--- a/src/main/java/api/json/GoblintMessageJsonHandler.java
+++ b/src/main/java/api/json/GoblintMessageJsonHandler.java
@@ -30,7 +30,8 @@ public class GoblintMessageJsonHandler extends MessageJsonHandler {
                 .registerTypeAdapterFactory(new TupleTypeAdapters.TwoTypeAdapterFactory())
                 .registerTypeAdapterFactory(new EnumTypeAdapter.Factory())
                 .registerTypeAdapterFactory(new GoblintMessageTypeAdapter.Factory(this))
-                .registerTypeAdapter(GoblintMessagesResult.Tag.class, new GoblintTagInterfaceAdapter());
+                .registerTypeAdapter(GoblintMessagesResult.Tag.class, new GoblintTagInterfaceAdapter())
+                .registerTypeAdapter(GoblintMessagesResult.MultiPiece.class, new GoblintMultiPieceInterfaceAdapter());
     }
 
 }

--- a/src/main/java/api/json/GoblintMultiPieceInterfaceAdapter.java
+++ b/src/main/java/api/json/GoblintMultiPieceInterfaceAdapter.java
@@ -1,0 +1,29 @@
+package api.json;
+
+import api.messages.GoblintMessagesResult;
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+
+/**
+ * The Class GoblintMultiPieceInterfaceAdapter.
+ * <p>
+ * Implements the JsonDeserializer to deserialize json to GoblintResult objects.
+ * In particular to differentiate between the Group and Piece (Single) classes.
+ *
+ * @author Karoliine Holter
+ * @since 0.0.4
+ */
+
+
+public class GoblintMultiPieceInterfaceAdapter implements JsonDeserializer<Object> {
+    @Override
+    public Object deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+        if (jsonObject.has("group_text"))
+            return jsonDeserializationContext.deserialize(jsonObject, GoblintMessagesResult.Group.class);
+        if (jsonObject.has("text"))
+            return jsonDeserializationContext.deserialize(jsonObject, GoblintMessagesResult.Piece.class);
+        return null;
+    }
+}

--- a/src/main/java/api/messages/GoblintMessagesResult.java
+++ b/src/main/java/api/messages/GoblintMessagesResult.java
@@ -72,7 +72,7 @@ public class GoblintMessagesResult {
             GoblintPosition pos = getLocation(loc);
             String msg = joinTags(tags) + " " + text;
             GoblintMessagesAnalysisResult result = new GoblintMessagesAnalysisResult(pos, msg, severity);
-            return new ArrayList<>(List.of(result));
+            return List.of(result);
         }
     }
 
@@ -102,7 +102,7 @@ public class GoblintMessagesResult {
             List<GoblintMessagesAnalysisResult> resultsWithoutRelated =
                     pieces.stream().map(piece -> new GoblintMessagesAnalysisResult(getLocation(piece.loc), groupText, piece.text, severity)).toList();
             // Add related warnings to all the pieces in the group
-            List<GoblintMessagesAnalysisResult> resultsWithRelated = new ArrayList<>();
+            List<AnalysisResult> resultsWithRelated = new ArrayList<>();
             for (GoblintMessagesAnalysisResult result : resultsWithoutRelated) {
                 resultsWithRelated.add(
                         new GoblintMessagesAnalysisResult(
@@ -114,7 +114,7 @@ public class GoblintMessagesResult {
                                         .map(res -> Pair.make(res.position(), res.text()))
                                         .toList()));
             }
-            return new ArrayList<>(resultsWithRelated);
+            return resultsWithRelated;
         }
 
         public List<AnalysisResult> convertGroup(List<Tag> tags, String severity) {
@@ -132,7 +132,7 @@ public class GoblintMessagesResult {
                             .orElse(getLocation(group_loc));
             GoblintMessagesAnalysisResult result =
                     new GoblintMessagesAnalysisResult(pos, joinTags(tags) + " " + group_text, severity, relatedFromPieces);
-            return new ArrayList<>(List.of(result));
+            return List.of(result);
         }
     }
 

--- a/src/main/java/api/messages/GoblintMessagesResult.java
+++ b/src/main/java/api/messages/GoblintMessagesResult.java
@@ -60,7 +60,7 @@ public class GoblintMessagesResult {
         private GoblintLocation loc;
 
         /**
-         * Converts the Single (Piece) type of Goblint messages from the
+         * Converts the Single (Piece type of) Goblint messages from the
          * GoblintMessagesResult type to AnalysisResult that are needed for MagPieBridge.
          *
          * @param tags     the tags of the warning given by Goblint
@@ -82,7 +82,7 @@ public class GoblintMessagesResult {
         private final List<Piece> pieces = new ArrayList<>();
 
         /**
-         * Converts the Single (Piece) type of Goblint messages from the
+         * Converts the Group Goblint messages from the
          * GoblintMessagesResult type to AnalysisResult that are needed for MagPieBridge.
          *
          * @param tags     the tags of the warning given by Goblint


### PR DESCRIPTION
Until now, the `Multipiece` class was used for both handling the `Group` and `Single` type of Goblint messages, having all fields from both of the records and thus making it messy. This PR adds the subclasses for `Group` and `Single` and deserializes the `multipiece` from JSON to the appropriate classes.