### PR TITLE
Make ambiguous paths unavailable instead throwing an error

### DIFF
--- a/src/main/java/abstractdebugging/AbstractDebuggingServer.java
+++ b/src/main/java/abstractdebugging/AbstractDebuggingServer.java
@@ -817,7 +817,7 @@ public class AbstractDebuggingServer implements IDebugProtocolServer {
         onThreadsStopped("step", primaryThreadId);
     }
 
-    private EdgeInfo findTargetEdge(EdgeInfo primaryTargetEdge, List<? extends EdgeInfo> candidateEdges, String threadName) throws IllegalStepException {
+    private EdgeInfo findTargetEdge(EdgeInfo primaryTargetEdge, List<? extends EdgeInfo> candidateEdges, String threadName) {
         // This is will make ambiguous threads unavailable if there are multiple distinct target edges with the same target CFG node.
         // TODO: Somehow ensure this can never happen.
         //  Options:

--- a/src/main/java/abstractdebugging/AbstractDebuggingServer.java
+++ b/src/main/java/abstractdebugging/AbstractDebuggingServer.java
@@ -836,7 +836,7 @@ public class AbstractDebuggingServer implements IDebugProtocolServer {
                 .filter(e -> e.cfgNodeId().equals(primaryTargetEdge.cfgNodeId()))
                 .toList();
         if (targetEdgesByCFGNode.size() > 1) {
-            log.info("Disabling synchronous stepping in the debugging thread \"" + threadName + "\", as the path there is ambiguous.");
+            log.warn("Disabling synchronous stepping in the debugging thread \"" + threadName + "\", as the path there is ambiguous.");
         }
         return targetEdgesByCFGNode.size() == 1 ? targetEdgesByCFGNode.get(0) : null;
     }

--- a/src/main/java/abstractdebugging/AbstractDebuggingServer.java
+++ b/src/main/java/abstractdebugging/AbstractDebuggingServer.java
@@ -818,7 +818,7 @@ public class AbstractDebuggingServer implements IDebugProtocolServer {
     }
 
     private EdgeInfo findTargetEdge(EdgeInfo primaryTargetEdge, List<? extends EdgeInfo> candidateEdges, String threadName) throws IllegalStepException {
-        // This is will throw if there are multiple distinct target edges with the same target CFG node.
+        // This is will make ambiguous threads unavailable if there are multiple distinct target edges with the same target CFG node.
         // TODO: Somehow ensure this can never happen.
         //  Options:
         //  * Throw error (current approach) (problem: might make it impossible to step at all in some cases. it is difficult to provide meaningful error messages for all cases)
@@ -836,7 +836,7 @@ public class AbstractDebuggingServer implements IDebugProtocolServer {
                 .filter(e -> e.cfgNodeId().equals(primaryTargetEdge.cfgNodeId()))
                 .toList();
         if (targetEdgesByCFGNode.size() > 1) {
-            throw new IllegalStepException("Path is ambiguous for " + threadName + ".");
+            log.info("Disabling synchronous stepping in the debugging thread \"" + threadName + "\", as the path there is ambiguous.");
         }
         return targetEdgesByCFGNode.size() == 1 ? targetEdgesByCFGNode.get(0) : null;
     }


### PR DESCRIPTION
Solves #73 