### PR TITLE
Bugfix: 

### DIFF
--- a/src/main/java/abstractdebugging/AbstractDebuggingServer.java
+++ b/src/main/java/abstractdebugging/AbstractDebuggingServer.java
@@ -811,9 +811,11 @@ public class AbstractDebuggingServer implements IDebugProtocolServer {
         for (var step : steps) {
             ThreadState thread = step.getLeft();
             EdgeInfo targetEdge = step.getRight();
-            NodeInfo targetNode = resultsService.lookupNode(targetEdge.nodeId());
-            boolean isNewThread = targetEdge instanceof FunctionCallEdgeInfo fce && fce.createsNewThread();
-            thread.pushFrame(new StackFrameState(targetNode, false, thread.getCurrentFrame().getLocalThreadIndex() - (isNewThread ? 1 : 0)));
+            if (targetEdge != null) {
+                NodeInfo targetNode = resultsService.lookupNode(targetEdge.nodeId());
+                boolean isNewThread = targetEdge instanceof FunctionCallEdgeInfo fce && fce.createsNewThread();
+                thread.pushFrame(new StackFrameState(targetNode, false, thread.getCurrentFrame().getLocalThreadIndex() - (isNewThread ? 1 : 0)));
+            }
         }
 
         onThreadsStopped("step", primaryThreadId);


### PR DESCRIPTION
When setting a breakpoint to the paper demo on line 21, and starting the debugger, stepping results in an "internal error". This is caused by `targetEdge` getting a `null` value, after which `targetEdge.nodeId()` is called, causing a `NullPointerException`. Without this proposed fix, the debugger will show a notification box with "Internal error" but will recover and step forward once a stepping button is pushed again.

The bug is probably caused by the fix from #74, where now the return statement `return targetEdgesByCFGNode.size() == 1 ? targetEdgesByCFGNode.get(0) : null;` of function `findTargetEdge` is reached (previously an exception was always thrown), and thus, the `targetEdge` in `stepAllThreadsIntoMatchingEdge` can get a `null` value.